### PR TITLE
Refine StudioCore loader

### DIFF
--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -64,6 +64,12 @@ def _load_monolith(name: str) -> Tuple[Optional[Type[Any]], Optional[Type[Any]],
         module = importlib.import_module(f".{name}", package=__name__)
     except ImportError as exc:  # pragma: no cover - diagnostics only
         return None, None, "missing", str(exc)
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        # Preserve the historical "safe loader" behaviour by ensuring unexpected
+        # import-time failures still allow the fallback path to run.  Diagnostics
+        # capture the error so callers can inspect the failure reason.
+        message = f"Failed to import monolith '{name}': {type(exc).__name__}: {exc}"
+        return None, None, "error", message
 
     version = getattr(module, "STUDIOCORE_VERSION", "unknown")
     core_cls = getattr(module, "StudioCore", None)


### PR DESCRIPTION
## Summary
- replace the side-effect heavy loader in `studiocore/__init__.py` with a structured loader that can prioritise v6, v5, or fallback engines via environment variables
- add a `LoaderDiagnostics` dataclass and helper accessors so tooling can inspect which engine was selected and why
- expose richer `get_core` logic that tries multiple candidates and surfaces meaningful errors instead of printing during import

## Testing
- python -m compileall studiocore/__init__.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b38a50108327bedd3d702fdee36a)