### PR TITLE
Capture monolith version

### DIFF
--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -64,6 +64,7 @@ try:
     core_mod = importlib.import_module(f".{monolith_name}", package=__name__)
     StudioCore = getattr(core_mod, "StudioCore", None)
     StudioCoreV5 = getattr(core_mod, "StudioCoreV5", None)
+    MONOLITH_VERSION = getattr(core_mod, "STUDIOCORE_VERSION", "unknown")
     print(f"🎧 [StudioCore Loader] Loaded {monolith_name} (version={MONOLITH_VERSION})")
 except ImportError as e:
     print(f"⚠️ [StudioCore Loader] ImportError: {e}")


### PR DESCRIPTION
## Summary
- ensure the loader reads the `STUDIOCORE_VERSION` attribute from the selected monolith module
- include the version in the loader log output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a14cac4cc83278a547108335df11b)