### PR TITLE
Handle monolith import exceptions

### DIFF
--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -64,6 +64,12 @@ def _load_monolith(name: str) -> Tuple[Optional[Type[Any]], Optional[Type[Any]],
         module = importlib.import_module(f".{name}", package=__name__)
     except ImportError as exc:  # pragma: no cover - diagnostics only
         return None, None, "missing", str(exc)
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        # Preserve the historical "safe loader" behaviour by ensuring unexpected
+        # import-time failures still allow the fallback path to run.  Diagnostics
+        # capture the error so callers can inspect the failure reason.
+        message = f"Failed to import monolith '{name}': {type(exc).__name__}: {exc}"
+        return None, None, "error", message
 
     version = getattr(module, "STUDIOCORE_VERSION", "unknown")
     core_cls = getattr(module, "StudioCore", None)


### PR DESCRIPTION
## Summary
- extend `_load_monolith` to catch unexpected exceptions in addition to `ImportError`
- surface those failures through `LoaderDiagnostics` so the loader can still fall back to `StudioCoreFallback`

## Testing
- python -m compileall studiocore/__init__.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c88508d6c832793f1455ee178e0e2)