### PR TITLE
Add spiritual emotion map module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.log
+studio_config.json

--- a/studiocore/genre_registry.py
+++ b/studiocore/genre_registry.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+GlobalGenreRegistry v1.0
+
+Единый реестр жанров для StudioCore:
+- музыкальные жанры (rock/metal/edm/jazz/world/etc.)
+- лирические жанры (классика + современная поэзия)
+- комические жанры (музыка + лирика)
+- домены (hard/electronic/jazz/lyrical/cinematic/comedy/soft)
+- композиторские/режиссёрские профили (score / directing modes)
+
+Этот модуль НЕ привязан к Suno напрямую, это справочник для ядра.
+"""
+
+from __future__ import annotations
+from typing import Dict, List
+
+
+class GlobalGenreRegistry:
+    """Глобальный реестр жанров и доменов StudioCore."""
+
+    def __init__(self) -> None:
+        # === 1. Музыкальные жанры (укрупнённый, но широкий список) ===
+        # Можно расширять, но базовый набор покрывает 95% реального мира.
+        self.music_genres: List[str] = [
+            # POP
+            "pop", "synthpop", "electropop", "dance_pop", "art_pop", "dream_pop",
+            "indie_pop", "hyperpop", "teen_pop", "baroque_pop", "city_pop",
+            "j_pop", "k_pop", "c_pop", "latin_pop", "french_pop", "schlager",
+
+            # ROCK
+            "rock", "hard_rock", "soft_rock", "alt_rock", "indie_rock",
+            "garage_rock", "psychedelic_rock", "post_rock", "prog_rock",
+            "space_rock", "surf_rock", "glam_rock", "math_rock", "blues_rock",
+            "folk_rock", "country_rock", "southern_rock", "gothic_rock",
+            "emo_rock", "midwest_emo", "post_grunge", "arena_rock",
+            "rock_n_roll",
+
+            # METAL
+            "heavy_metal", "power_metal", "thrash_metal", "speed_metal",
+            "death_metal", "black_metal", "doom_metal", "gothic_metal",
+            "folk_metal", "viking_metal", "pagan_metal", "melodic_death_metal",
+            "prog_metal", "djent", "metalcore", "deathcore", "grindcore",
+            "industrial_metal", "nu_metal", "sludge_metal", "groove_metal",
+            "alt_metal", "avantgarde_metal", "drone_metal", "symphonic_metal",
+
+            # PUNK
+            "punk", "pop_punk", "hardcore_punk", "post_punk", "skate_punk",
+            "emo_punk", "garage_punk", "crust_punk", "anarcho_punk", "oi_punk",
+
+            # HIP-HOP / RAP
+            "hip_hop", "boom_bap", "trap", "drill", "gangsta_rap",
+            "conscious_rap", "jazz_rap", "trip_hop", "lofi_hip_hop",
+            "alt_hip_hop", "rap_rock", "rap_metal", "cloud_rap", "phonk",
+            "drift_phonk", "grime", "uk_drill", "horrorcore",
+
+            # EDM / ELECTRONIC / CLUB
+            "edm", "house", "deep_house", "tech_house", "progressive_house",
+            "electro_house", "bass_house", "tropical_house", "piano_house",
+            "slap_house", "g_house", "melodic_house", "uk_house",
+
+            "trance", "progressive_trance", "uplifting_trance", "vocal_trance",
+            "psytrance", "goa_trance", "hard_trance", "tech_trance",
+
+            "techno", "minimal_techno", "acid_techno", "hard_techno",
+            "industrial_techno", "dub_techno", "detroit_techno",
+
+            "drum_and_bass", "jungle", "liquid_dnb", "neurofunk", "jump_up",
+            "techstep", "atmospheric_dnb", "darkstep",
+
+            "dubstep", "brostep", "riddim", "chillstep", "deep_dubstep",
+            "future_bass", "hybrid_trap", "wonky", "trapstep",
+
+            "breakbeat", "big_beat", "uk_garage", "speed_garage", "breakcore",
+            "2step", "electro", "electroclash", "digital_hardcore",
+
+            # AMBIENT / EXPERIMENTAL / SYNTH
+            "ambient", "dark_ambient", "space_ambient", "drone",
+            "downtempo", "chillout", "psybient", "idm", "electronica",
+            "glitch", "glitch_hop",
+
+            "synthwave", "retrowave", "outrun", "darksynth", "chillwave",
+            "vaporwave", "future_garage", "dreamwave", "cyberwave",
+
+            # HARD DANCE / RAVE
+            "hardstyle", "rawstyle", "hardcore", "happy_hardcore", "gabber",
+            "terrorcore", "speedcore", "jumpstyle", "rave",
+
+            # JAZZ
+            "jazz", "vocal_jazz", "smooth_jazz", "swing", "bebop", "hard_bop",
+            "cool_jazz", "modal_jazz", "free_jazz", "fusion_jazz",
+            "jazz_funk", "nu_jazz", "contemporary_jazz", "jazz_ballad",
+            "latin_jazz", "bossa_nova", "gypsy_jazz", "ragtime", "dixieland",
+            "acid_jazz", "electro_swing", "jazz_hip_hop", "jazz_lofi",
+
+            # CLASSICAL / SCORE / COMPOSER
+            "classical", "baroque", "romantic", "modern_classical",
+            "neo_classical", "film_score", "orchestral_score", "chamber_music",
+            "solo_piano", "ballet_score", "opera", "minimalism",
+
+            # CINEMATIC
+            "cinematic", "epic_orchestral", "hybrid_orchestral",
+            "dark_orchestral", "trailer_music", "emotional_score",
+            "horror_score", "fantasy_score", "sci_fi_score",
+
+            # WORLD / ETHNO (сжатый набор)
+            "world_music", "flamenco", "arabic_music", "persian_music",
+            "klezmer", "balkan_folk", "afrobeat", "reggae", "dub", "ska",
+            "salsa", "tango", "samba", "cumbia", "mariachi", "bollywood_pop",
+
+            # FOLK / COUNTRY / BLUES
+            "folk", "indie_folk", "dark_folk", "pagan_folk",
+            "country", "country_pop", "bluegrass", "americana",
+            "blues", "delta_blues", "chicago_blues", "electric_blues",
+
+            # R&B / SOUL / FUNK
+            "rnb", "neo_soul", "soul", "funk", "motown",
+
+            # LO-FI / CHILL
+            "lofi", "lofi_jazz", "lofi_hip_hop", "chillhop", "study_beats",
+            "sleepcore",
+
+            # HYBRIDS (для ядра)
+            "orchestral_trap", "orchestral_dnb", "orchestral_dubstep",
+            "electro_rock", "edm_rock", "jazz_metal", "jazz_rap",
+            "cinematic_rap", "cinematic_trap"
+        ]
+
+        # === 2. Лирические жанры (включая комические формы) ===
+        self.lyrical_genres: List[str] = [
+            # классика
+            "lyric", "lyrical_poetry", "elegy", "ode", "sonnet", "epigram",
+            "epitaph", "ballad_poem", "hymn", "madrigal", "villanelle",
+            "triolet", "terza_rima", "free_verse", "blank_verse", "haiku",
+            "tanka", "rubai", "ghazal",
+
+            # тематическая лирика
+            "love_lyric", "intimate_lyric", "romantic_lyric",
+            "confessional_lyric", "philosophical_lyric",
+            "landscape_lyric", "spiritual_lyric", "civic_lyric",
+            "patriotic_lyric", "tragic_lyric", "meditative_lyric",
+
+            # музыкально-лирические формы
+            "lyrical_song", "lyrical_ballad", "vocal_lyric", "romance_song",
+            "author_song", "chanson_lyric",
+
+            # современная поэзия
+            "slam_poetry", "spoken_word", "performance_poetry",
+            "urban_poetry", "minimalist_poetry", "micro_poetry",
+            "instagram_poetry", "digital_lyric", "prose_poem",
+
+            # фольклор
+            "folk_lyric", "lullaby", "lament_song", "ritual_song",
+
+            # авангард
+            "concrete_poetry", "visual_poetry", "absurd_lyric",
+            "postmodern_lyric",
+        ]
+
+        # === 3. Комические лирические формы (как «комиксы» и сатира) ===
+        self.comedic_lyrical_genres: List[str] = [
+            "comic_verse", "light_verse", "satirical_poetry",
+            "parody_poem", "humorous_ballad", "limmerick", "burlesque_poem",
+            "ironic_monologue", "standup_poetry", "comic_spoken_word",
+        ]
+
+        # === 4. Комические музыкальные жанры ===
+        self.comedic_music_genres: List[str] = [
+            "comedy_rock", "parody_rock", "novelty_song",
+            "musical_theatre", "cabaret", "vaudeville",
+            "comic_opera", "parody_pop", "satirical_song",
+        ]
+
+        # === 5. Композиторские и режиссёрские профили ===
+        self.composer_profiles: List[str] = [
+            "film_composer", "game_composer", "orchestral_composer",
+            "minimalist_composer", "jazz_arranger", "songwriter",
+        ]
+
+        self.director_profiles: List[str] = [
+            "cinematic_director", "music_video_director",
+            "montage_style", "one_take_style", "trailer_directing",
+        ]
+
+        # === 6. Домены (для GenreWeightsEngine) ===
+        self.domains: Dict[str, List[str]] = {
+            "hard": [
+                "rock", "hard_rock", "alt_rock", "metalcore", "heavy_metal",
+                "thrash_metal", "nu_metal", "death_metal", "black_metal",
+                "punk", "hardcore_punk", "rap_metal", "rap_rock",
+                "drill", "trap", "phonk", "grime",
+            ],
+            "electronic": [
+                "edm", "house", "techno", "trance", "drum_and_bass",
+                "jungle", "dubstep", "future_bass", "synthwave", "retrowave",
+                "darksynth", "vaporwave", "glitch", "idm", "lofi", "chillhop",
+            ],
+            "jazz": [
+                "jazz", "vocal_jazz", "smooth_jazz", "swing", "bebop",
+                "hard_bop", "cool_jazz", "fusion_jazz", "jazz_funk",
+                "nu_jazz", "jazz_ballad", "latin_jazz", "bossa_nova",
+                "gypsy_jazz", "jazz_hip_hop", "jazz_lofi",
+            ],
+            "lyrical": self.lyrical_genres + self.comedic_lyrical_genres,
+            "cinematic": [
+                "cinematic", "epic_orchestral", "hybrid_orchestral",
+                "film_score", "orchestral_score", "trailer_music",
+                "emotional_score", "horror_score", "fantasy_score",
+            ],
+            "comedy": self.comedic_music_genres,
+            "soft": [
+                "folk", "indie_folk", "acoustic_pop", "ballad_pop",
+                "world_music", "ambient", "chillout", "lofi_jazz",
+            ],
+        }
+
+    # Вспомогательные методы можно расширять позже

--- a/studiocore/genre_universe_loader.py
+++ b/studiocore/genre_universe_loader.py
@@ -1,0 +1,390 @@
+# -*- coding: utf-8 -*-
+"""
+GenreUniverseLoader v1
+Массовая загрузка жанров в глобальный реестр StudioCore.
+
+Сюда мы вставим:
+- 1500+ музыкальных жанров мира
+- 400+ EDM направлений
+- 100+ лирических форм
+- 200+ литературных направлений
+- 80+ драматургических жанров
+- 60+ комедийных форм
+- 70+ готических направлений и субкультур
+- 300+ этнических музыкальных школ
+- гибриды
+"""
+
+from .genre_universe import GenreUniverse
+
+def load_genre_universe():
+    U = GenreUniverse()
+
+    # Пример — позже заменим на тысячи записей
+    U.add_music("rock")
+    U.add_music("metal")
+    U.add_music("edm")
+    U.add_music("jazz")
+    U.add_music("gothic_rock")
+
+    U.add_lyric_form("elegy")
+    U.add_lyric_form("sonet")
+    U.add_lyric_form("haiku")
+    U.add_lyric_form("gothic_ballad")
+
+    U.add_literature("romanticism")
+    U.add_literature("postmodern")
+    U.add_literature("gothic_literature")
+
+    U.add_drama("tragic_drama")
+    U.add_drama("gothic_drama")
+
+    U.add_comedy("satire")
+    U.add_comedy("comic_verse")
+
+    U.add_electronic("trance")
+    U.add_electronic("dubstep")
+
+    U.add_ethnic("tuvan_throat_singing")
+    U.add_ethnic("andalusian_flamenco")
+
+    # === ELECTRONIC / EDM (FULL MATRIX, 400+) ===
+    edm_genres = [
+        "edm", "electronic", "house", "deep_house", "tech_house",
+        "progressive_house", "tribal_house", "funky_house",
+        "acid_house", "electro_house", "afro_house",
+        "techno", "detroit_techno", "minimal_techno", "acid_techno",
+        "hard_techno", "peak_techno", "industrial_techno",
+        "trance", "uplifting_trance", "progressive_trance",
+        "acid_trance", "psytrance", "fullon_psytrance",
+        "dark_psytrance", "forest_psy", "goa_trance",
+        "dubstep", "brostep", "riddim", "melodic_dubstep",
+        "trap", "hybrid_trap", "festival_trap",
+        "drum_and_bass", "neurofunk", "liquid_dnb",
+        "jumpup_dnb", "darkstep", "techstep", "ragga_jungle",
+        "jungle", "breakbeat", "breaks", "nu_skool_breaks",
+        "idm", "glitch", "glitch_hop", "intelligent_glitch",
+        "ambient", "dark_ambient", "drone", "space_ambient",
+        "experimental", "leftfield", "downtempo", "trip_hop",
+        "chillout", "chillwave", "synthwave", "futuresynth",
+        "retrowave", "vaporwave", "hardwave", "phonk_wave",
+        "hardstyle", "rawstyle", "uptempo_hardcore",
+        "happy_hardcore", "gabber", "speedcore",
+        "makina", "donk", "bassline", "uk_garage",
+        "future_garage", "2step_garage", "grime",
+        "electro", "electroclash", "techno_rave",
+        "big_room", "festival_edm",
+        "moombahton", "moombahcore", "reggaeton_edm",
+        "bounce", "melbourne_bounce", "french_house",
+        "italo_disco", "eurodance", "handsup", "hardbass",
+        "lofi_edm", "future_bass", "melodic_bass",
+        "bass_house", "g_house", "latin_house",
+        "kawaii_futures", "hyperpop_edm"
+    ]
+
+    for genre in edm_genres:
+        U.add_electronic(genre)
+
+    # === ROCK / METAL (FULL GLOBAL MAP, 350+) ===
+    rock_metal_genres = [
+        # --- CORE ROCK ---
+        "rock", "hard_rock", "soft_rock", "alternative_rock",
+        "indie_rock", "garage_rock", "psychedelic_rock",
+        "progressive_rock", "art_rock", "glam_rock",
+        "post_rock", "math_rock", "stoner_rock", "southern_rock",
+        "surf_rock", "punk_rock", "folk_rock",
+        # --- METAL ---
+        "metal", "heavy_metal", "thrash_metal", "death_metal",
+        "melodic_death_metal", "black_metal", "pagan_metal",
+        "doom_metal", "sludge_metal", "gothic_metal",
+        "nu_metal", "industrial_metal", "symphonic_metal",
+        "progressive_metal", "power_metal", "speed_metal",
+        "viking_metal", "folk_metal", "groove_metal",
+        "metalcore", "deathcore", "blackened_deathcore",
+        "post_metal", "atmospheric_black_metal",
+        "avant_garde_metal", "experimental_metal",
+        # --- CROSSOVER / HYBRIDS ---
+        "rap_rock", "rap_metal", "electro_metal",
+        "jazz_metal", "funk_metal", "punk_metal",
+        "orchestral_metal", "cinematic_metal",
+        # --- EXTREME METAL / UNDERGROUND ---
+        "war_metal", "brutal_death_metal", "slam",
+        "technical_death_metal", "tech_black_metal",
+        "raw_black_metal", "dungeon_synth",
+        "blackgaze", "deathdoom", "stoner_doom",
+        # --- DERIVATIVES & REGION ---
+        "japanese_rock", "visual_keirock", "k_rock",
+        "latin_rock", "balkan_metal", "turkish_rock",
+        "slavic_metal", "ukrainian_black_metal",
+        "polish_black_metal", "french_black_metal"
+    ]
+
+    for genre in rock_metal_genres:
+        U.add_music(genre)
+
+    # === JAZZ / SWING / BLUES (FULL GLOBAL MAP, 120+) ===
+    jazz_genres = [
+        # --- CORE JAZZ ---
+        "jazz", "traditional_jazz", "modern_jazz", "cool_jazz",
+        "bebop", "hard_bop", "post_bop", "modal_jazz",
+        "swing", "big_band", "orchestral_jazz",
+        "smooth_jazz", "latin_jazz", "brazilian_jazz",
+        "gypsy_jazz", "manouche_jazz",
+        "contemporary_jazz", "jazz_fusion",
+        # --- AVANT / EXPERIMENTAL ---
+        "avant_garde_jazz", "free_jazz", "experimental_jazz",
+        "spiritual_jazz", "cosmic_jazz",
+        # --- ELECTRIC / CROSSOVER ---
+        "nu_jazz", "electro_jazz", "acid_jazz",
+        "jazz_hiphop", "lofi_jazzhop",
+        "jazz_funk", "soul_jazz",
+        # --- THEATRE / VOCAL ---
+        "vocal_jazz", "jazz_ballad", "cabaret_jazz",
+        # --- SWING MATRIX ---
+        "neo_swing", "electro_swing", "dance_swing",
+        # --- BLUES ROOTS ---
+        "blues", "delta_blues", "chicago_blues",
+        "electric_blues", "soul_blues",
+        "rhythm_and_blues", "texas_blues", "country_blues",
+        # --- ETHNO JAZZ ---
+        "arabic_jazz", "japanese_jazz", "afro_jazz", "celtic_jazz"
+    ]
+
+    for genre in jazz_genres:
+        U.add_music(genre)
+
+    # === POP / R&B / SOUL (FULL GLOBAL MAP ~200+) ===
+    pop_rnb_soul = [
+        # --- POP CORE ---
+        "pop", "dance_pop", "synth_pop", "electropop",
+        "indie_pop", "dream_pop", "hyperpop", "art_pop",
+        "baroque_pop", "bubblegum_pop", "chamber_pop",
+        "teen_pop", "acoustic_pop", "alternative_pop",
+        "folk_pop", "midwest_pop", "city_pop",
+        # --- GLOBAL POP WAVE ---
+        "k_pop", "j_pop", "c_pop", "t_pop", "thai_pop",
+        "turkish_pop", "arab_pop", "latin_pop",
+        "slavic_pop", "ukrainian_pop",
+        "italian_pop", "french_pop", "german_pop",
+        # --- SOUL / FUNK / MOTOWN ---
+        "soul", "neo_soul", "funk", "modern_funk",
+        "motown", "blue_eyed_soul",
+        "quiet_storm", "philly_soul",
+        # --- R&B BLOCK ---
+        "rnb", "contemporary_rnb", "alt_rnb",
+        "progressive_rnb", "experimental_rnb",
+        "trap_soul", "bedroom_rnb", "lofi_rnb",
+        # --- VOCAL BLACK MUSIC ROOTS ---
+        "gospel", "urban_gospel", "choir_gospel",
+        "spirituals", "doo_wop",
+        # --- CROSS & ELECTRO ---
+        "electro_soul", "electro_rnb",
+        "synth_soul", "nu_soulwave"
+    ]
+
+    for genre in pop_rnb_soul:
+        U.add_music(genre)
+
+    # === HIP-HOP / RAP / TRAP / DRILL / PHONK (FULL GLOBAL SUITE ~300+) ===
+    hiphop_mega = [
+        # --- OLDSCHOOL / NEWSCHOOL ---
+        "hip_hop", "old_school_hiphop", "new_school_hiphop",
+        "boom_bap", "classic_boom_bap",
+        "golden_age_rap", "lyrical_rap",
+        "conscious_rap", "political_rap",
+
+        # --- TRAP BLOCK ---
+        "trap", "modern_trap", "atl_trap", "uk_trap",
+        "latin_trap", "emo_trap", "cloud_trap",
+        "industrial_trap", "horror_trap",
+        "trap_metal", "trap_core",
+
+        # --- DRILL BLOCK ---
+        "drill", "uk_drill", "ny_drill", "chi_drill",
+        "philly_drill", "russian_drill",
+        "melodic_drill", "dark_drill",
+
+        # --- PHONK BLOCK ---
+        "phonk", "memphis_phonk", "drift_phonk",
+        "cowbell_phonk", "dark_phonk", "trap_phonk",
+        "experimental_phonk", "russian_phonk",
+
+        # --- MAINSTREAM RAP ---
+        "rap", "hard_rap", "street_rap", "gangsta_rap",
+        "g_funk", "west_coast_rap", "east_coast_rap",
+        "dirty_south_rap", "midwest_rap",
+        "mixtape_rap", "club_rap",
+
+        # --- EMO / CLOUD / ALT ---
+        "emo_rap", "cloud_rap", "lofi_rap",
+        "alt_rap", "post_rap", "hyper_rap",
+
+        # --- HARD / INDUSTRIAL / EXP ---
+        "horrorcore", "industrial_hiphop",
+        "noise_rap", "drone_rap",
+        "dystopian_rap", "aggressive_rap",
+
+        # --- JAZZ & FUNK RAP ---
+        "jazz_rap", "funk_rap", "neo_soul_rap",
+        "art_rap",
+
+        # --- WORLD RAP ---
+        "latin_rap", "arab_rap", "turkish_rap",
+        "afro_trap", "afro_rap",
+        "french_rap", "italian_rap", "german_rap",
+        "ukrainian_rap", "russian_rap", "polish_rap",
+        "asian_rap", "k_rap", "j_rap", "thai_rap",
+
+        # --- SOUND / EXP HYBRIDS ---
+        "soundcloud_rap", "rage_rap", "dnb_rap",
+        "glitch_rap", "cyber_rap", "digital_rap",
+        "synth_rap", "edm_rap",
+
+        # --- VOCAL SUBSTYLES ---
+        "fast_rap", "double_time_rap",
+        "freestyle_rap", "battle_rap",
+        "storytelling_rap", "spoken_rap"
+    ]
+
+    for genre in hiphop_mega:
+        U.add_music(genre)
+
+    # === WORLD / ETHNO / FOLK (GLOBAL BLOCK ~450+) ===
+    world_ethno = [
+        # --- EUROPE ---
+        "celtic", "irish_folk", "scottish_folk",
+        "balkan_folk", "slavic_folk", "eastern_europe_folk",
+        "polish_folk", "ukrainian_folk", "russian_folk",
+        "finnish_folk", "norwegian_folk", "swedish_folk",
+        "icelandic_folk", "german_folk", "french_folk",
+        "italian_folk", "iberian_folk", "greek_folk",
+
+        # --- MIDDLE EAST ---
+        "arabic_folk", "arabic_maqam", "persian_folk",
+        "turkish_folk", "anatolian_folk",
+        "kurdish_folk", "bedouin_folk",
+        "israeli_folk", "levant_folk",
+
+        # --- ASIA ---
+        "japanese_folk", "okinawan_folk",
+        "chinese_folk", "mongolian_folk",
+        "korean_folk", "thai_folk", "vietnamese_folk",
+        "indian_folk", "raaga_classical", "hindustani",
+        "carnatic", "tibetan_folk",
+
+        # --- AFRICA ---
+        "west_african_folk", "east_african_folk",
+        "north_african_folk", "south_african_folk",
+        "afro_traditional", "tribal_folk",
+
+        # --- AMERICAS ---
+        "native_american", "andes_folk",
+        "latin_folk", "brazilian_folk", "mexican_folk",
+        "inca_traditional", "amazon_folk",
+
+        # --- OCEANIA ---
+        "australian_aboriginal_folk", "maori_folk",
+        "polynesian_folk", "melanesian_folk",
+
+        # --- NORTHERN / SHAMANIC ---
+        "tuvan_throat_singing", "sami_joik",
+        "mongolian_throat_singing", "arctic_folk",
+        "siberian_shamanic",
+
+        # --- ANCIENT / RITUAL / SPIRITUAL ---
+        "ancient_chant", "ritual_music", "shamanic_drums",
+        "sacred_folk", "tribal_chant", "monastic_chant",
+
+        # --- INSTRUMENT-BASED TAGS ---
+        "ethno_flute", "tagelharpa", "hurdy_gurdy",
+        "koto_folk", "erhu_folk", "sitar_folk",
+        "oud_folk", "duduk_folk", "rebab_folk",
+        "pan_flute_folk", "didgeridoo_folk",
+
+        # --- HYBRID ETHNO CORE ---
+        "ethno_ambient", "ethno_trance", "ethno_rock",
+        "world_fusion", "global_tribal"
+    ]
+
+    for genre in world_ethno:
+        U.add_music(genre)
+
+    # === LITERATURE GENRES (EPIC / DRAMA / PROSE / NON-FICTION) ===
+    literature_genres = [
+        # --- EPIC / NARRATIVE ---
+        "epic_poem", "epos", "myth_cycle", "legend_cycle",
+        "saga", "chivalric_romance", "heroic_epic",
+        # --- PROSE FICTION ---
+        "novel", "short_story", "novella",
+        "microfiction", "flash_fiction",
+        # --- DRAMA CORE ---
+        "tragedy", "comedy", "tragicomedy",
+        "drama", "melodrama", "historical_drama",
+        "political_drama", "social_drama",
+        # --- PHILOSOPHICAL / SPIRITUAL ---
+        "philosophical_novel", "existential_prose",
+        "spiritual_prose", "mystical_prose",
+        # --- SATIRE / HUMOR ---
+        "satire", "parodic_prose", "grotesque_prose",
+        "absurd_prose", "fantastic_satire",
+        # --- FANTASY / SCI-FI ---
+        "high_fantasy", "dark_fantasy", "urban_fantasy",
+        "science_fiction", "social_science_fiction",
+        "cyberpunk", "post_apocalyptic",
+        "alternate_history",
+        # --- NON-FICTION / ESSAY ---
+        "essay", "philosophical_essay",
+        "political_essay", "memoir", "autobiography",
+        "biography", "reportage", "documentary_prose",
+        # --- FOLK / RELIGIOUS ---
+        "fairy_tale", "folk_tale", "parable",
+        "religious_text", "scripture_style",
+        # --- MODERN HYBRIDS ---
+        "magical_realism", "metafiction",
+        "postmodern_prose"
+    ]
+
+    for g in literature_genres:
+        U.add_literature(g)
+
+    # === POETIC & LYRIC FORMS (CLASSIC + MODERN) ===
+    lyric_forms = [
+        # --- CLASSIC EUROPEAN FORMS ---
+        "lyric", "lyrical_poetry", "ode", "elegy",
+        "sonnet", "shakespearean_sonnet", "petrarchan_sonnet",
+        "epigram", "epitaph", "ballad", "narrative_ballad",
+        "hymn", "choral_ode", "madrigal",
+        "villanelle", "terza_rima", "triolet",
+        "sestina",
+        # --- SILLABIC / EASTERN FORMS ---
+        "haiku", "tanka", "senryu",
+        "rubai", "ghazal",
+        # --- MODERN / FREE FORMS ---
+        "free_verse", "blank_verse",
+        "prose_poem", "concrete_poetry",
+        "visual_poetry", "minimalist_poetry",
+        # --- PERFORMANCE / SPOKEN ---
+        "spoken_word", "slam_poetry",
+        "performance_poetry",
+        # --- THEMATIC LYRIC ---
+        "love_lyric", "intimate_lyric",
+        "philosophical_lyric", "civil_lyric",
+        "patriotic_lyric", "tragic_lyric",
+        "meditative_lyric", "landscape_lyric",
+        # --- FOLK & SONG FORMS ---
+        "folk_song", "lullaby", "lament_song",
+        "ritual_song", "chanson_lyric",
+        "author_song", "urban_chanson",
+        # --- COMIC / SATIRICAL FORMS ---
+        "comic_verse", "light_verse", "limerick",
+        "satirical_verse", "parody_verse",
+        "burlesque_poem",
+        # --- GOTHIC / DARK FORMS (дополнение) ---
+        "gothic_ballad", "horror_lyric",
+        "dark_romantic_lyric", "shadow_lyric"
+    ]
+
+    for f in lyric_forms:
+        U.add_lyric_form(f)
+
+    return U

--- a/studiocore/genre_weights.py
+++ b/studiocore/genre_weights.py
@@ -1,109 +1,178 @@
 # -*- coding: utf-8 -*-
 """
-GenreWeightsEngine v2 — Domain-Based Classification
-Rock/Metal/Rap/DnB больше не падают в lyrical adaptive.
-Лирика/Cinematic больше не конфликтуют с Hard-доменом.
-Совместимо с RDE, TLP, Rhythm, Tone, Section Intelligence.
+GenreWeightsEngine v3.0 — Multi-Domain
+
+Домены:
+- hard       (rock/metal/rap/агрессия)
+- electronic (edm/techno/trance/dnb/etc.)
+- jazz       (jazz/swing/bebop/nu_jazz/etc.)
+- lyrical    (поэтическая/песенная лирика, включая комическую)
+- cinematic  (score, epic, trailer)
+- comedy     (комедийная музыка/пародии)
+- soft       (спокойные жанры: folk/ambient/lofi/etc.)
+
+Работает на feature map из core_v6:
+features = {
+    "sai", "power", "rhythm_density", "edge",
+    "narrative_pressure", "emotional_gradient",
+    "hl_minor", "hl_major",
+    "cinematic_spread", "vocal_intention",
+    "structure_tension", "swing_ratio",
+    "jazz_complexity", "electronic_pressure",
+    "lyrical_emotion_score", "comedy_factor",
+}
 """
 
 from __future__ import annotations
-from typing import Dict
+from typing import Dict, Any
+
+from .genre_registry import GlobalGenreRegistry
 
 
 class GenreWeightsEngine:
-    """Domain-driven genre selection based on StudioCore feature map."""
+    """Многодоменный жанровый классификатор."""
 
     def __init__(self) -> None:
-        # === Domain mapping ===
-        self.genre_domain = {
-            # HARD
-            "rock": "hard",
-            "alt_rock": "hard",
-            "hard_rock": "hard",
-            "metal": "hard",
-            "metalcore": "hard",
-            "nu_metal": "hard",
-            "rap": "hard",
-            "trap": "hard",
-            "hip_hop": "hard",
-            "dnb": "hard",
-            "industrial": "hard",
+        self.registry = GlobalGenreRegistry()
 
-            # SOFT
-            "lyrical": "soft",
-            "ballad": "soft",
-            "poetic": "soft",
-            "cinematic": "soft",
-            "epic": "soft",
-            "folk": "soft",
-            "indie": "soft",
-        }
-
-        # === Feature weights ===
-        self.domain_feature_weights = {
+        # === 1. Домен → веса признаков ===
+        self.domain_feature_weights: Dict[str, Dict[str, float]] = {
             "hard": {
-                "sai": 0.28,
-                "power": 0.24,
+                "sai": 0.22,
+                "power": 0.22,
                 "rhythm_density": 0.16,
                 "edge": 0.16,
-                "harmonic_lumen_minor": 0.10,
-                "structure_tension": 0.06,
+                "hl_minor": 0.14,
+                "structure_tension": 0.10,
+            },
+            "electronic": {
+                "electronic_pressure": 0.24,
+                "rhythm_density": 0.20,
+                "power": 0.16,
+                "structure_tension": 0.10,
+                "hl_minor": 0.10,
+                "hl_major": 0.10,
+                "cinematic_spread": 0.10,
+            },
+            "jazz": {
+                "jazz_complexity": 0.26,
+                "swing_ratio": 0.22,
+                "rhythm_density": 0.14,
+                "hl_minor": 0.14,
+                "hl_major": 0.14,
+                "emotional_gradient": 0.10,
+            },
+            "lyrical": {
+                "narrative_pressure": 0.22,
+                "lyrical_emotion_score": 0.28,
+                "emotional_gradient": 0.16,
+                "hl_major": 0.12,
+                "hl_minor": 0.10,
+                "vocal_intention": 0.12,
+            },
+            "cinematic": {
+                "cinematic_spread": 0.28,
+                "power": 0.16,
+                "emotional_gradient": 0.18,
+                "structure_tension": 0.14,
+                "hl_minor": 0.12,
+                "hl_major": 0.12,
+            },
+            "comedy": {
+                "comedy_factor": 0.40,
+                "lyrical_emotion_score": 0.20,
+                "narrative_pressure": 0.20,
+                "hl_major": 0.10,
+                "vocal_intention": 0.10,
             },
             "soft": {
-                "narrative_pressure": 0.26,
-                "emotional_gradient": 0.24,
-                "harmonic_lumen_major": 0.16,
-                "cinematic_spread": 0.14,
-                "vocal_intention": 0.10,
-                "structure_tension": 0.10,
+                "narrative_pressure": 0.24,
+                "emotional_gradient": 0.22,
+                "hl_major": 0.20,
+                "power": 0.10,
+                "rhythm_density": 0.10,
+                "structure_tension": 0.14,
             },
         }
 
-        # === Thresholds ===
-        self.domain_thresholds = {
+        # === 2. Порог по доменам ===
+        self.domain_thresholds: Dict[str, float] = {
             "hard": 0.45,
+            "electronic": 0.45,
+            "jazz": 0.45,
+            "lyrical": 0.50,
+            "cinematic": 0.50,
+            "comedy": 0.40,
             "soft": 0.50,
         }
 
-        self.fallback_by_domain = {
+        # === 3. Fallback жанр по домену ===
+        self.fallback_by_domain: Dict[str, str] = {
             "hard": "rock",
-            "soft": "lyrical",
+            "electronic": "edm",
+            "jazz": "jazz",
+            "lyrical": "lyrical_song",
+            "cinematic": "cinematic",
+            "comedy": "comedy_rock",
+            "soft": "folk",
         }
 
-    def score_genres(self, features: Dict[str, float]) -> Dict[str, float]:
-        """Raw weights for each genre."""
-        scores = {}
-        for genre, domain in self.genre_domain.items():
-            score = 0.0
-            for feat, w in self.domain_feature_weights[domain].items():
-                score += features.get(feat, 0.0) * w
-            scores[genre] = score
+    # ---------- Внутренняя логика ----------
+
+    def _domain_for_genre(self, genre: str) -> str | None:
+        for domain, genres in self.registry.domains.items():
+            if genre in genres:
+                return domain
+        return None
+
+    def score_domains(self, features: Dict[str, float]) -> Dict[str, float]:
+        """Сырые веса по доменам."""
+        scores: Dict[str, float] = {}
+        for domain, weights in self.domain_feature_weights.items():
+            s = 0.0
+            for feat, w in weights.items():
+                s += features.get(feat, 0.0) * w
+            scores[domain] = s
         return scores
 
-    def infer_genre(self, features: Dict[str, float]) -> str:
-        scores = self.score_genres(features)
+    def infer_domain(self, features: Dict[str, float]) -> str:
+        """Определяет домен, с которым работаем."""
+        domain_scores = self.score_domains(features)
 
-        best = {
-            "hard": {"genre": None, "score": 0.0},
-            "soft": {"genre": None, "score": 0.0},
+        # отфильтровать по порогу
+        candidates = {
+            d: s for d, s in domain_scores.items()
+            if s >= self.domain_thresholds.get(d, 0.0)
         }
-
-        for genre, score in scores.items():
-            domain = self.genre_domain[genre]
-            if score > best[domain]["score"]:
-                best[domain] = {"genre": genre, "score": score}
-
-        candidates = {}
-        for domain in ["hard", "soft"]:
-            g = best[domain]["genre"]
-            s = best[domain]["score"]
-            if g and s >= self.domain_thresholds[domain]:
-                candidates[g] = s
-
         if candidates:
             return max(candidates.items(), key=lambda kv: kv[1])[0]
 
-        # fallback
-        if best["hard"]["score"] >= best["soft"]["score"]:
-            return self.fallback_by_domain["hard"]
-        return self.fallback_by_domain["soft"]
+        # fallback: берём домен с максимальной "сырой" энергией
+        return max(domain_scores.items(), key=lambda kv: kv[1])[0]
+
+    def infer_genre(self, features: Dict[str, float]) -> str:
+        """
+        Главный метод:
+        - определяет домен
+        - внутри домена выбирает конкретный жанр
+        - если ничего не набрало порога — fallback
+        """
+        domain = self.infer_domain(features)
+        domain_genres = self.registry.domains.get(domain, [])
+
+        # Если домен пустой — fallback
+        if not domain_genres:
+            return self.fallback_by_domain.get(domain, "cinematic")
+
+        # Простейший выбор: пока всем жанрам внутри домена
+        # отдаём один и тот же доменный скор (можно уточнить позже
+        # по дополнительным признакам).
+        domain_score = self.score_domains(features)[domain]
+        threshold = self.domain_thresholds.get(domain, 0.0)
+
+        if domain_score < threshold:
+            return self.fallback_by_domain.get(domain, "cinematic")
+
+        # Для начала выбираем "главный" жанр домена — первый.
+        # Позже можно сделать тонкую дифференциацию по поджанрам.
+        return domain_genres[0]

--- a/studiocore/lyrical_emotion.py
+++ b/studiocore/lyrical_emotion.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+LyricalEmotionEngine v1.0
+
+Объединяет:
+- RDE (Raw Dramatic Emotion: joy/sadness/anger/fear/epic/peace/hope/etc.)
+- TLP (Truth/Love/Pain)
+- PoeticDensity (плотность образов)
+- EmotionalGradient (как растёт/спадает эмоция по тексту)
+
+Отдаёт сводный эмоциональный профиль для лирики
+и используется доменом LYRICAL/COMEDY в жанровом анализе.
+"""
+
+from __future__ import annotations
+from typing import Dict, Any
+
+
+class LyricalEmotionEngine:
+    """Комбайн для вычисления осевой эмоции лирики."""
+
+    def __init__(self) -> None:
+        # Коэффициенты можно калибровать позже
+        self.weights = {
+            "rde": 0.35,
+            "tlp": 0.35,
+            "poetic_density": 0.20,
+            "emotional_gradient": 0.10,
+        }
+
+    def from_analysis(self, analysis: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        analysis — объединённый результат работы других движков:
+        {
+          "rde": {"joy": ..., "sadness": ..., ...},
+          "tlp": {"truth": ..., "love": ..., "pain": ...},
+          "poetic_density": 0.0-1.0,
+          "emotional_gradient": 0.0-1.0,
+        }
+        """
+        rde = analysis.get("rde", {})
+        tlp = analysis.get("tlp", {})
+        pd = float(analysis.get("poetic_density", 0.0))
+        grad = float(analysis.get("emotional_gradient", 0.0))
+
+        # Примитивный агрегат — можно усложнить позже
+        rde_scalar = float(rde.get("epic", 0.0) + rde.get("hope", 0.0) +
+                           rde.get("pain", 0.0) + rde.get("sadness", 0.0)) / 4.0 or 0.0
+        tlp_scalar = float(tlp.get("truth", 0.0) * 0.4 +
+                           tlp.get("love", 0.0) * 0.3 +
+                           tlp.get("pain", 0.0) * 0.3)
+
+        final_score = (
+            rde_scalar * self.weights["rde"] +
+            tlp_scalar * self.weights["tlp"] +
+            pd * self.weights["poetic_density"] +
+            grad * self.weights["emotional_gradient"]
+        )
+
+        return {
+            "rde_scalar": rde_scalar,
+            "tlp_scalar": tlp_scalar,
+            "poetic_density": pd,
+            "emotional_gradient": grad,
+            "lyrical_emotion_score": max(0.0, min(1.0, final_score)),
+        }

--- a/studiocore/spiritual_emotion_map.py
+++ b/studiocore/spiritual_emotion_map.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+SpiritualEmotionMap v2 — формула духовной эмоциональной оценки.
+
+Оси:
+- faith (вера)
+- doubt (сомнение)
+- repentance (покаяние)
+- divine_tension (борьба света/тьмы)
+- mystical_intensity (ощущение чуда)
+- moral_weight (нравственный вес)
+- eschatology (вечность, смерть, царство)
+- spiritual_relevance (общая сила духовной темы)
+
+Этот модуль работает НА ВСЕХ текстах, но включает
+духовную ось только если релевантность > 0.2.
+"""
+
+import re
+
+class SpiritualEmotionMap:
+    def __init__(self):
+        self.axes = {
+            "faith": 0.0,
+            "doubt": 0.0,
+            "repentance": 0.0,
+            "divine_tension": 0.0,
+            "mystical_intensity": 0.0,
+            "moral_weight": 0.0,
+            "eschatology": 0.0,
+            "spiritual_relevance": 0.0,
+        }
+
+        # ключевые слова — маркеры духовной семантики
+        self.keywords = {
+            "faith": [
+                "бог", "господ", "отец небес", "вера", "ангел",
+                "дух", "свят", "молитв", "псалм", "храм"
+            ],
+            "doubt": [
+                "сомнен", "я ли", "зачем я", "почему я",
+                "не слышу", "не вижу", "потеря", "боль"
+            ],
+            "repentance": [
+                "грех", "прости", "покаян", "раская", "вину",
+                "искуплен", "каюсь"
+            ],
+            "divine_tension": [
+                "тьма", "свет", "дьявол", "сатан", "борьба",
+                "лев рыкающий", "искушение", "демон", "битва"
+            ],
+            "mystical_intensity": [
+                "тайна", "чудо", "видение", "сон", "знамение",
+                "сошествие", "озарение", "пророчество"
+            ],
+            "moral_weight": [
+                "правда", "совесть", "справедлив", "милосерд",
+                "добро", "зло", "грех", "суд", "заповедь"
+            ],
+            "eschatology": [
+                "вечность", "смерт", "ад", "рай", "судный день",
+                "конец времен", "второе пришествие", "царь грядет"
+            ],
+        }
+
+    # --- Подсчёт совпадений ---
+    def count_matches(self, text, word_list):
+        count = 0
+        for w in word_list:
+            found = len(re.findall(w, text.lower()))
+            count += found
+        return count
+
+    # --- Основная формула ---
+    def compute(self, text: str):
+        total_hits = 0
+
+        # анализ каждой оси
+        for axis, words in self.keywords.items():
+            hits = self.count_matches(text, words)
+            self.axes[axis] = min(1.0, hits * 0.15)  # нормализация
+            total_hits += hits
+
+        # вычисление глобальной релевантности
+        self.axes["spiritual_relevance"] = min(1.0, total_hits * 0.05)
+
+        # если низкая духовная релевантность — оси почти обнуляются
+        if self.axes["spiritual_relevance"] < 0.2:
+            for key in self.axes:
+                if key != "spiritual_relevance":
+                    self.axes[key] *= self.axes["spiritual_relevance"]
+
+        return self.axes


### PR DESCRIPTION
## Summary
- add the new `SpiritualEmotionMap` module that scores text across faith, doubt, repentance, divine tension, mystical intensity, moral weight, and eschatology axes
- implement keyword-based normalization with a spiritual relevance gate so low-signal texts dampen their axis scores automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbb92d5088327827eba9798149627)