### PR TITLE
Add protective licensing and fingerprint markers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,31 @@
-MIT License (with additional usage restrictions)
-
+MIT License (Enhanced Attribution Version)
 Copyright (c) 2025 Сергей Бауэр (@Sbauermaner)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+in the Software exclusively under the following conditions:
 
-1. The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
-2. The Software may **not** be used to train, fine-tune, or otherwise develop
-   machine learning or AI models.
-3. The Software may **not** be used to operate, power, or provide commercial
-   prompt-generation, prompt-tuning, or prompt-selling services.
+1. The above copyright notice and the NOTICE file must be included in all
+   copies or substantial portions of the Software, without modification,
+   removal, renaming, or obscuring.
+
+2. Use of the names "StudioCore", "StudioCore API", "StudioCore MAXI",
+   the Author’s personal name, identity, style, brand, project structure,
+   documentation style, narrative logic, musical analysis logic,
+   or any project-related trademarks is prohibited for:
+   • commercial use,
+   • advertising,
+   • SaaS,
+   • promotion,
+   • AI training,
+   • derivative branding,
+   unless express written permission is granted by the Author.
+
+3. This license applies ONLY to the source-code portion of the Software.
+   All rights to the brand, identity, naming, ecosystem, models, datasets,
+   creative structure, text structure, analysis methods, prompts, musical
+   and literary frameworks remain exclusively with the Author.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY ARISING FROM THE USE OR INABILITY TO USE THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+StudioCore — Copyright © 2025 Сергей Бауэр (Sbauermaner)
+All rights reserved for name, brand, trademarks, identity, design, models,
+algorithms, project structure, documentation, and StudioCore ecosystem.
+
+This NOTICE file is an integral part of the MIT license and MUST be included
+with all copies and substantial portions of the Software.
+
+The name "StudioCore", the brand, the project structure, the algorithms,
+the narrative style, the documentation style, and all visual/semantic
+identifiers remain the exclusive intellectual property of the Author.
+
+Use of the StudioCore name, brand, project identity, or any derivative brand
+for commercial, promotional, AI-training, SaaS, or redistribution purposes
+requires explicit written permission from the Author (Telegram @S_Bauer8).
+
+MIT license applies ONLY to source-code usage.
+All rights to name, brand, ecosystem, and project identity are reserved.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# 🔒 StudioCore — Protected MIT-Licensed Codebase
+**Author: Сергей Бауэр (@Sbauermaner)**
+
+Using this software implies acceptance of the Enhanced MIT License and NOTICE.  
+Only the raw source code is licensed under MIT.  
+The StudioCore name, brand, project identity, algorithms, models, documentation style,  
+and musical/literary analysis frameworks are NOT licensed under MIT and remain the exclusive  
+intellectual property of the Author.
+
 # StudioCore v6.4 MAXI — Adaptive Music Intelligence / Адаптивный музыкальный интеллект
 
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
@@ -10,7 +19,7 @@
 ---
 
 ## 🇷🇺 Обзор
-StudioCore v6.4 MAXI — статлес-движок для анализа лирики и генерации музыкальных подсказок. FastAPI и Gradio оборачивают ядро StudioCoreV6, обеспечивая HTTP API, публичный UI и встроенные самопроверки. Все лишние файлы удалены, конфигурация готова к публичному релизу.
+StudioCore v6.4 MAXI — статлес-движок для анализа лирики и генерации музыкальных подсказок. FastAPI и Gradio оборачивают ядро StudioCoreV6, обеспечивая HTTP API, UI, доступный в рамках условий MIT, и встроенные самопроверки. Все лишние файлы удалены, конфигурация готова к релизу в рамках условий MIT.
 
 ### Возможности
 - Анализ текста: жанр, BPM, тональность, эмоции, вокал, структурные секции.
@@ -50,7 +59,7 @@ StudioCore v6.4 MAXI — статлес-движок для анализа ли�
 ---
 
 ## 🇬🇧 Overview
-StudioCore v6.4 MAXI is a stateless lyric-analysis engine wrapped by FastAPI and Gradio. It exposes StudioCoreV6 with clean diagnostics, reload controls, and a public UI. The repository has been cleaned for a production-ready GitHub release.
+StudioCore v6.4 MAXI is a stateless lyric-analysis engine wrapped by FastAPI and Gradio. It exposes StudioCoreV6 with clean diagnostics, reload controls, and a UI available under MIT licensing terms. The repository has been cleaned for a production-ready GitHub release.
 
 ### Features
 - Text analysis: genre, BPM, key, emotions, vocal profile, and structural sections.

--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -8,10 +8,13 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Tuple, Type
 
+FINGERPRINT = "StudioCore-FP-2025-SB-9fd72e27"
+
 from .core_v6 import StudioCoreV6
 from .fallback import StudioCoreFallback
 
-STUDIOCORE_VERSION = "v6.4-maxi"
+# Version fingerprint linked to FINGERPRINT: StudioCore-FP-2025-SB-9fd72e27
+STUDIOCORE_VERSION = "6.4.0-protected"
 DEFAULT_MONOLITH = "monolith_v4_3_1"
 DEFAULT_LOADER_ORDER = ("v6", "v5", "monolith", "fallback")
 
@@ -241,6 +244,7 @@ __all__ = [
     "StudioCoreFallback",
     "get_core",
     "loader_diagnostics",
+    "FINGERPRINT",
     "STUDIOCORE_VERSION",
     "MONOLITH_VERSION",
     "DEFAULT_LOADER_ORDER",

--- a/studiocore/app.py
+++ b/studiocore/app.py
@@ -9,6 +9,14 @@ import sys
 from pathlib import Path
 from studiocore import StudioCore, STUDIOCORE_VERSION
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 
 def main():
     """

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -8,6 +8,7 @@ structured data so downstream tooling can evolve without breaking imports.
 from __future__ import annotations
 
 import copy
+import os
 import re
 from dataclasses import asdict
 from typing import Any, Dict, Iterable, Sequence
@@ -44,6 +45,21 @@ from .text_utils import (
     translate_text_for_analysis,
 )
 from .user_override_manager import UserOverrideManager, UserOverrides
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
+STUDIOCORE_LICENSE_ENV = os.getenv("STUDIOCORE_LICENSE", "").strip()
+
+# Anti-piracy soft hook (does not block execution, only marks environment intent)
+if STUDIOCORE_LICENSE_ENV == "":
+    # Это "юридический крючок": факт запуска без указания лицензии можно трактовать как несанкционированное использование.
+    pass
 
 
 class StudioCoreV6:

--- a/studiocore/emotion.py
+++ b/studiocore/emotion.py
@@ -9,6 +9,14 @@ import math
 from typing import Dict, Any
 import logging
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 # Получаем логгер для этого модуля
 log = logging.getLogger(__name__)
 

--- a/studiocore/genre_matrix_extended.py
+++ b/studiocore/genre_matrix_extended.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 
 class GenreMatrixEngine:
     """Naïve keyword matcher that approximates classical genre families."""

--- a/studiocore/logger.py
+++ b/studiocore/logger.py
@@ -7,6 +7,14 @@ import logging
 import sys
 import os # v2: Добавлен os для определения уровня лога
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 # v2: Уровень по умолчанию INFO, но можно переопределить через app.py
 LOG_LEVEL = logging.DEBUG if os.environ.get("STUDIOCORE_DEBUG") else logging.INFO
 

--- a/studiocore/monolith_v4_3_1.py
+++ b/studiocore/monolith_v4_3_1.py
@@ -14,9 +14,17 @@ from typing import Dict, Any, List, Tuple, Optional
 import logging
 
 # === 1. Импорт ядра ===
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 from .config import load_config
 # v16: ИСПРАВЛЕН ImportError
-from .text_utils import normalize_text_preserve_symbols, extract_raw_blocks 
+from .text_utils import normalize_text_preserve_symbols, extract_raw_blocks
 # v15: Исправлен ImportError (возвращаем оригинальные имена)
 from .emotion import AutoEmotionalAnalyzer, TruthLovePainEngine
 from .tone import ToneSyncEngine

--- a/studiocore/rhythm.py
+++ b/studiocore/rhythm.py
@@ -15,6 +15,14 @@ import re
 import statistics
 from typing import Dict, List, Optional, Tuple, TypedDict
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+# AI_TRAINING_PROHIBITED: Redistribution or training of AI models on this codebase
+# without explicit written permission from the Author is prohibited.
+
 from .text_utils import extract_sections
 
 PUNCT_WEIGHTS = {


### PR DESCRIPTION
## Summary
- replace repository licensing files with enhanced MIT terms and accompanying NOTICE
- update README to highlight protected branding and MIT licensing language
- embed fingerprint constants and protective signature blocks across StudioCore modules

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e1c64a5f88332a28046b0442e6217)