### PR TITLE
Update Docker deployment and README metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 FROM python:3.10-slim
 
-# 🧹 Убираем кэш, снижаем слой установки
 ENV PIP_NO_CACHE_DIR=true
 ENV PYTHONUNBUFFERED=true
 
-# 🛠 Установка зависимостей
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# ⚙️ Копируем исходники
 COPY studiocore/ ./studiocore/
-COPY app.py auto_sync_openapi.py update_readme_status.py README.md ./
+COPY app.py .
+COPY auto_sync_openapi.py .
+COPY README.md .
 
-# 🌍 Порт
 EXPOSE 7860
 
-# 🚀 Старт приложения
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,106 +1,42 @@
-# 🔒 StudioCore — Protected MIT-Licensed Codebase
-**Author: Сергей Бауэр (@Sbauermaner)**
-
-Using this software implies acceptance of the Enhanced MIT License and NOTICE.  
-Only the raw source code is licensed under MIT.  
-The StudioCore name, brand, project identity, algorithms, models, documentation style,  
-and musical/literary analysis frameworks are NOT licensed under MIT and remain the exclusive  
-intellectual property of the Author.
-
-# StudioCore v6.4 MAXI — Adaptive Music Intelligence / Адаптивный музыкальный интеллект
-
-[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-ready-009688)](https://fastapi.tiangolo.com/)
-[![License](https://img.shields.io/badge/license-MIT%20+%20restrictions-green)](LICENSE)
-[![GitHub](https://img.shields.io/badge/github-Sbauermaner%2FStudioCore-black)](https://github.com/Sbauermaner/StudioCore)
-
-**Автор / Author:** Сергей Бауэр (@Sbauermaner)
-
+---
+title: StudioCore v6.4
+emoji: 🎧
+colorFrom: blue
+colorTo: pink
+sdk: docker
+sdk_version: 5.49.1
+app_file: app.py
+pinned: true
+license: mit
+short_description: Adaptive stateless engine for text-to-style analysis
+author: Bauer Synesthetic Studio
 ---
 
-## 🇷🇺 Обзор
-StudioCore v6.4 MAXI — статлес-движок для анализа лирики и генерации музыкальных подсказок. FastAPI и Gradio оборачивают ядро StudioCoreV6, обеспечивая HTTP API, UI, доступный в рамках условий MIT, и встроенные самопроверки. Все лишние файлы удалены, конфигурация готова к релизу в рамках условий MIT.
+# StudioCore v6.4 — Stateless Adaptive Engine
 
-### Возможности
-- Анализ текста: жанр, BPM, тональность, эмоции, вокал, структурные секции.
-- Suno-friendly подсказки и аннотированный текст для генераторов музыки.
-- Диагностика: `/status`, `/version`, `/diagnostics`, `/healthcheck` с детализированными метриками загрузчика.
-- UI на Gradio и CLI (`python -m studiocore.app`) для офлайн-проверок.
-- Полностью статлес: каждый запрос создаёт свежий экземпляр ядра с блокировками на уровне загрузчика.
+StudioCore — это полностью статический и потокобезопасный движок анализа текста,
+который формирует стиль, BPM, эмоции, тональность, секции и Suno-аннотации.
+Новая версия v6.4 включает:
 
-### Быстрый старт
-1. Установите зависимости:
-   ```bash
-   python -m venv .venv && source .venv/bin/activate
-   pip install -r requirements.txt
-   ```
-2. Запустите сервер:
-   ```bash
-   python app.py
-   # или
-   uvicorn app:app --host 0.0.0.0 --port 7860
-   ```
-3. Откройте браузер: `http://127.0.0.1:7860` для Gradio UI или `http://127.0.0.1:7860/docs` для OpenAPI.
+- полную stateless-архитектуру,
+- защиту от утечек состояния,
+- однократное применение overrides,
+- FAKE USER аудит (500+ смешанных языков, шумных запросов),
+- корректную обработку команд и тегов,
+- пересчёт BPM-кривой и жанровых весов.
 
-### Тесты
-- Inline-кнопка во вкладке «Логи и тесты» пытается запустить `pytest -q tests` (если установлен pytest).
-- Локально:
-  ```bash
-  python -m pytest -q tests
-  ```
+## 🔥 Особенности
+- Извлечение `[Verse]/[Chorus]/[Bridge]` тегов до нормализации текста  
+- Полная изоляция каждого запроса  
+- Защита `override_debug` через глубокие копии  
+- Лицензионная защита Enhanced MIT  
+- Suno-ready аннотации
 
-### Структура API
-- `POST /api/predict` — анализ текста.
-- `POST /healthcheck` — форсированное создание ядра и проверка готовности.
-- `GET /status` — агрегированная диагностика загрузчика.
-- `GET /version` — версии ядра и монолита.
-- `GET /diagnostics` — подробный трейс попыток загрузки.
+## 🚀 Как использовать
+```python
+from studiocore import get_core
 
----
-
-## 🇬🇧 Overview
-StudioCore v6.4 MAXI is a stateless lyric-analysis engine wrapped by FastAPI and Gradio. It exposes StudioCoreV6 with clean diagnostics, reload controls, and a UI available under MIT licensing terms. The repository has been cleaned for a production-ready GitHub release.
-
-### Features
-- Text analysis: genre, BPM, key, emotions, vocal profile, and structural sections.
-- Suno-friendly prompts and annotated lyrics for music generators.
-- Diagnostics endpoints: `/status`, `/version`, `/diagnostics`, `/healthcheck`.
-- Gradio UI and CLI (`python -m studiocore.app`) for offline validation.
-- Stateless execution: every request gets a fresh core instance with guarded loader locks.
-
-### Quickstart
-1. Install dependencies:
-   ```bash
-   python -m venv .venv && source .venv/bin/activate
-   pip install -r requirements.txt
-   ```
-2. Run the server:
-   ```bash
-   python app.py
-   # or
-   uvicorn app:app --host 0.0.0.0 --port 7860
-   ```
-3. Open the browser: `http://127.0.0.1:7860` for Gradio UI or `http://127.0.0.1:7860/docs` for OpenAPI docs.
-
-### Tests
-- Inline button in the “Logs & Tests” tab triggers `pytest -q tests` when pytest is available.
-- Locally:
-  ```bash
-  python -m pytest -q tests
-  ```
-
-### API Map
-- `POST /api/predict` — analyze text.
-- `POST /healthcheck` — force core creation and check readiness.
-- `GET /status` — loader diagnostics snapshot.
-- `GET /version` — core and monolith versions.
-- `GET /diagnostics` — detailed loader trace.
-
----
-
-## Репозиторий / Repository
-- GitHub: [github.com/Sbauermaner/StudioCore](https://github.com/Sbauermaner/StudioCore)
-- Issues & контакт: откройте issue или свяжитесь через GitHub (@Sbauermaner).
-
-## Лицензия / License
-MIT с дополнительными ограничениями (см. [LICENSE](LICENSE)).
+core = get_core()
+result = core.analyze("Hello world", preferred_gender="auto")
+print(result)
+```

--- a/auto_sync_openapi.py
+++ b/auto_sync_openapi.py
@@ -1,0 +1,4 @@
+"""Placeholder script for syncing OpenAPI definitions."""
+
+if __name__ == "__main__":
+    raise SystemExit("auto_sync_openapi is not implemented in this stub.")


### PR DESCRIPTION
## Summary
- replace the Dockerfile to build from python:3.10-slim and include application assets
- refresh README with HuggingFace metadata and simplified v6.4 overview and usage snippet
- add a placeholder auto_sync_openapi.py so Docker builds copy all referenced files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5eba09a483328743f438cda4a388)