### PR TITLE
Use Pydantic model for debug endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,8 +158,14 @@ async def status():
 # ===============================================
 # NEW: stable JSON debug endpoint
 # ===============================================
+
+
+class DebugRequest(BaseModel):
+    text: str
+
+
 @app.post("/debug_json")
-async def debug_json(text: str):
+async def debug_json(req: DebugRequest):
     """
     Возвращает полный JSON-payload, минуя Gradio и консоль.
     Используется для диагностики: prompt_suno_style, annotated_text_suno,
@@ -167,7 +173,7 @@ async def debug_json(text: str):
     """
 
     core = create_core_instance(force_reload=False)
-    result = core.analyze(text, preferred_gender="auto")
+    result = core.analyze(req.text, preferred_gender="auto")
     return {"debug": True, "payload": result}
 
 


### PR DESCRIPTION
## Summary
- wrap the /debug_json endpoint request body in a Pydantic model
- access analyzed text from the validated request payload

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e64a52e188332afa9147cb3e48f3c)