### PR TITLE
Fix FANF slicing safety and dynamic annotations

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,6 +416,9 @@ def analyze_text(text: str, gender: str = "auto"):
 
         log.debug("Gradio -> core.analyze...")
         result = core.analyze(text, preferred_gender=gender, semantic_hints=semantic_hints or None)
+        result["fanf"] = core.build_fanf_output() or result.get("fanf", {})
+        result["annotated_text_ui"] = core.annotate_ui()
+        result["annotated_text_suno"] = core.annotate_suno()
 
         if isinstance(result, dict) and "error" in result:
             log.error(f"Gradio: Ядро вернуло ошибку: {result['error']}")

--- a/studiocore/suno_annotations.py
+++ b/studiocore/suno_annotations.py
@@ -10,13 +10,35 @@ class SunoAnnotationEngine:
     def build_suno_safe_annotations(self, sections: Sequence[str], diagnostics: Dict[str, Any]) -> List[str]:
         headers = self.generate_section_headers(sections)
         annotations = []
-        for idx, header in enumerate(headers):
-            meta = [header]
-            meta.extend(self.attach_bpm_and_fracture_commands(diagnostics, idx))
-            meta.extend(self.attach_vocal_and_instrumental_commands(diagnostics, idx))
-            meta.extend(self.insert_parenthesized_commands(diagnostics.get("commands", {}), idx))
-            annotations.append(" ".join(meta))
+        payload = {
+            "legacy": diagnostics.get("legacy", {}),
+            "out": diagnostics,
+        }
+        for header in headers:
+            annotations.append(self.build_annotation(payload, section_label=header))
         return self.protect_annotations_from_lyrics(annotations)
+
+    def build_annotation(self, payload: Dict[str, Any], section_label: str = "Section") -> str:
+        legacy = payload.get("legacy", {}) if isinstance(payload.get("legacy"), dict) else {}
+        out = payload.get("out", {}) if isinstance(payload.get("out"), dict) else {}
+        style = legacy.get("style", {}) if isinstance(legacy.get("style"), dict) else {}
+
+        genre = style.get("genre") or "auto"
+        mood = style.get("mood") or "auto"
+        energy = style.get("energy") or "auto"
+        arrangement = style.get("arrangement") or "auto"
+        bpm_source = legacy.get("bpm") if isinstance(legacy, dict) else None
+        if bpm_source is None:
+            bpm_source = out.get("bpm", {}).get("estimate") if isinstance(out.get("bpm"), dict) else None
+        key = style.get("key") or "auto"
+
+        bpm_label = bpm_source if bpm_source is not None else "auto"
+        try:
+            bpm_label = int(bpm_label)
+        except Exception:
+            bpm_label = bpm_label
+
+        return f"[{section_label} - AUTO - {mood}, {energy}, {arrangement}, BPM≈{bpm_label}] (Genre={genre}, Key={key})"
 
     def protect_annotations_from_lyrics(self, annotations: Sequence[str]) -> List[str]:
         return [f"({item})" if not item.startswith("(") else item for item in annotations]

--- a/studiocore/ui_builder.py
+++ b/studiocore/ui_builder.py
@@ -1,0 +1,16 @@
+"""Utility helpers for UI payload preparation."""
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+
+def coerce_sections(text_obj: Any) -> List[Any]:
+    """Return sections as a list regardless of the incoming container type."""
+    sections = getattr(text_obj, "sections", []) if text_obj is not None else []
+    if isinstance(sections, list):
+        return sections
+    if isinstance(sections, dict):
+        return list(sections.values())
+    if isinstance(sections, Iterable) and not isinstance(sections, (str, bytes)):
+        return list(sections)
+    return [sections] if sections else []


### PR DESCRIPTION
## Summary
- add safe section coercion and dynamic choir handling for FANF annotations
- expose rebuildable FANF output and annotation helpers through the core and UI
- update Suno annotations to use payload genres/keys and add section formatting

## Testing
- python -m pytest tests/test_fanf_engine.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7c6b85a88332a9a423f0df7a4cef)