### PR TITLE
Add emotion vector stubs to engine interfaces

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -341,6 +341,8 @@ class StudioCoreV6:
         if language_info:
             structure["language"] = dict(language_info)
 
+        result: Dict[str, Any] = {}
+
         zero_hint = self.text_engine.detect_zero_pulse(text, sections=sections)
 
         # 3. Emotional layers
@@ -357,6 +359,13 @@ class StudioCoreV6:
             "conflict": self.emotion_engine.emotion_conflict_map(emotion_profile),
         }
         emotion_payload = self._merge_semantic_hints(emotion_payload, semantic_hints.get("emotion", {}))
+
+        try:
+            from studiocore.emotion_profile import EmotionAggregator
+
+            result["_emotion_stub"] = EmotionAggregator
+        except Exception:
+            result["_emotion_stub"] = None
 
         # 4. Tonal colours and style hints
         color_profile = self.color_engine.assign_color_by_emotion(emotion_profile)
@@ -906,34 +915,36 @@ class StudioCoreV6:
         if semantic_hints.get("annotations"):
             annotations = self._merge_semantic_hints(annotations, semantic_hints["annotations"])
 
-        result = {
-            "legacy": legacy_result,
-            "structure": structure,
-            "emotion": emotion_payload,
-            "color": {
-                "profile": color_profile,
-                "wave": color_wave,
-                "transitions": color_transitions,
-            },
-            "vocal": vocal_payload,
-            "breathing": {**breathing_profile, "sync": breath_sync},
-            "bpm": bpm_payload,
-            "meaning": meaning_payload,
-            "tonality": tonality_payload,
-            "instrumentation": instrumentation_payload,
-            "rem": rem_payload,
-            "zero_pulse": zero_pulse_payload,
-            "tlp": dict(tlp_profile),
-            "style": style_payload,
-            "commands": command_payload,
-            "annotations": annotations,
-            "semantic_hints": semantic_hints,
-            "auto_context": structure_context,
-            "instrument_dynamics": instrument_dynamics_payload,
-            "override_debug": override_manager.debug_summary(),
-            "rde_summary": rde_summary,
-            "genre_analysis": genre_analysis,
-        }
+        result.update(
+            {
+                "legacy": legacy_result,
+                "structure": structure,
+                "emotion": emotion_payload,
+                "color": {
+                    "profile": color_profile,
+                    "wave": color_wave,
+                    "transitions": color_transitions,
+                },
+                "vocal": vocal_payload,
+                "breathing": {**breathing_profile, "sync": breath_sync},
+                "bpm": bpm_payload,
+                "meaning": meaning_payload,
+                "tonality": tonality_payload,
+                "instrumentation": instrumentation_payload,
+                "rem": rem_payload,
+                "zero_pulse": zero_pulse_payload,
+                "tlp": dict(tlp_profile),
+                "style": style_payload,
+                "commands": command_payload,
+                "annotations": annotations,
+                "semantic_hints": semantic_hints,
+                "auto_context": structure_context,
+                "instrument_dynamics": instrument_dynamics_payload,
+                "override_debug": override_manager.debug_summary(),
+                "rde_summary": rde_summary,
+                "genre_analysis": genre_analysis,
+            }
+        )
         fanf_analysis_payload = {
             "emotion": {"profile": emotion_profile, "curve": emotion_curve},
             "bpm": bpm_payload,

--- a/studiocore/emotion.py
+++ b/studiocore/emotion.py
@@ -9,6 +9,8 @@ import math
 from typing import Dict, Any
 import logging
 
+from studiocore.emotion_profile import EmotionVector, EmotionAggregator
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27
@@ -102,6 +104,19 @@ class TruthLovePainEngine: # <-- v15: Оригинальное имя
         log.debug(f"TLP результат: {result}")
         return result
 
+    def export_emotion_vector(self, text: str) -> EmotionVector:
+        """
+        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        """
+        return EmotionVector(
+            truth=0.0,
+            love=0.0,
+            pain=0.0,
+            valence=0.0,
+            arousal=0.0,
+            weight=1.0,
+        )
+
 
 # =====================================================
 # 💫 AutoEmotionalAnalyzer (v3 Словари)
@@ -180,4 +195,17 @@ class AutoEmotionalAnalyzer: # <-- v15: Оригинальное имя
         final_scores = {k: round(v, 3) for k, v in normalized.items() if k != "neutral" and v > 0.001}
         log.debug(f"Результат EMO (финал): {final_scores}")
         return final_scores
+
+    def export_emotion_vector(self, text: str) -> EmotionVector:
+        """
+        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        """
+        return EmotionVector(
+            truth=0.0,
+            love=0.0,
+            pain=0.0,
+            valence=0.0,
+            arousal=0.0,
+            weight=1.0,
+        )
 

--- a/studiocore/genre_matrix_extended.py
+++ b/studiocore/genre_matrix_extended.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from studiocore.emotion_profile import EmotionVector, EmotionAggregator
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27
@@ -118,6 +120,19 @@ class GenreMatrixEngine:
             "dominant": dominant,
             "keywords": keyword_hits,
         }
+
+    def export_emotion_vector(self, text: str) -> EmotionVector:
+        """
+        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        """
+        return EmotionVector(
+            truth=0.0,
+            love=0.0,
+            pain=0.0,
+            valence=0.0,
+            arousal=0.0,
+            weight=1.0,
+        )
 
 
 class GenreMatrixExtended(GenreMatrixEngine):

--- a/studiocore/rde_engine.py
+++ b/studiocore/rde_engine.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
+from studiocore.emotion_profile import EmotionVector, EmotionAggregator
+
 
 @dataclass(frozen=True)
 class RDESnapshot:
@@ -51,6 +53,19 @@ class RhythmDynamicsEmotionEngine:
             palette=palette,
         )
         return snapshot
+
+    def export_emotion_vector(self, text: str) -> EmotionVector:
+        """
+        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        """
+        return EmotionVector(
+            truth=0.0,
+            love=0.0,
+            pain=0.0,
+            valence=0.0,
+            arousal=0.0,
+            weight=1.0,
+        )
 
 
 __all__ = ["RDESnapshot", "RhythmDynamicsEmotionEngine"]

--- a/studiocore/tlp_engine.py
+++ b/studiocore/tlp_engine.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
+from studiocore.emotion_profile import EmotionVector, EmotionAggregator
+
 from .emotion import TruthLovePainEngine as _TruthLovePainEngine
 
 
@@ -22,6 +24,19 @@ class TruthLovePainEngine(_TruthLovePainEngine):
         profile["dominant_axis"] = dominant
         profile["balance"] = round((profile.get("truth", 0.0) + profile.get("love", 0.0)) - profile.get("pain", 0.0), 3)
         return profile
+
+    def export_emotion_vector(self, text: str) -> EmotionVector:
+        """
+        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        """
+        return EmotionVector(
+            truth=0.0,
+            love=0.0,
+            pain=0.0,
+            valence=0.0,
+            arousal=0.0,
+            weight=1.0,
+        )
 
 
 __all__ = ["TruthLovePainEngine"]


### PR DESCRIPTION
## Summary
- add safe EmotionVector/EmotionAggregator imports to emotion, TLP, RDE, and genre engines
- expose passive export_emotion_vector hooks returning neutral vectors across engines
- wire StudioCoreV6 to surface a passive EmotionAggregator stub prior to RDE processing

## Testing
- python -m compileall studiocore (fails at existing studiocore/symbiosis_audit.py syntax error)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f80daf62c833298a66de5af7fd2a2)