### PR TITLE
Add emotional smoothing field and passive routing

### DIFF
--- a/studiocore/bpm_engine.py
+++ b/studiocore/bpm_engine.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Sequence
 
+from .emotion_profile import EmotionVector
+
 from .logical_engines import BPMEngine as _CoreBPMEngine
 
 
@@ -28,6 +30,14 @@ class BPMEngine(_CoreBPMEngine):
             "poly_rhythm": poly,
             "target_energy": mapping.get("target_energy"),
         }
+
+    def apply_emotional_microshift(self, bpm: float, emotion: EmotionVector) -> float:
+        """
+        Emotional BPM micro-adjustment.
+        Soft shift: ±3% based on emotional arousal.
+        """
+        shift = (emotion.arousal - 0.5) * 0.06 * bpm
+        return bpm + shift
 
 
 __all__ = ["BPMEngine"]

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -11,9 +11,11 @@ import copy
 import os
 import re
 from dataclasses import asdict
-from typing import Any, Dict, Iterable, Sequence
+from typing import Any, Dict, Iterable, List, Sequence
 
 from .bpm_engine import BPMEngine
+from .emotion_field import EmotionFieldEngine
+from .emotion_profile import EmotionVector
 from .rde_engine import RhythmDynamicsEmotionEngine
 from .section_parser import SectionParser
 from .tlp_engine import TruthLovePainEngine
@@ -376,7 +378,8 @@ class StudioCoreV6:
         # 5. Vocal character
         voice_gender = self.vocal_engine.detect_voice_gender(text)
         voice_type = self.vocal_engine.detect_voice_type(text)
-        voice_tone = self.vocal_engine.detect_voice_tone(text)
+        voice_emotion_vector = self.emotion_engine.export_emotion_vector(text)
+        voice_tone = self.vocal_engine.detect_voice_tone(text, emotion=voice_emotion_vector)
         voice_style = self.vocal_engine.detect_vocal_style(text, voice_type=voice_type, voice_tone=voice_tone)
         vocal_dynamics = self.vocal_engine.vocal_dynamics_map(sections)
         vocal_curve = self.vocal_engine.vocal_intensity_curve(vocal_dynamics)
@@ -632,6 +635,16 @@ class StudioCoreV6:
         tokens = [token for token in re.split(r"[^a-z0-9а-яё]+", text_lower) if token]
         token_count = max(len(tokens), 1)
         lines = [ln.strip() for ln in text.split("\n") if ln.strip()]
+        emotion_engine = self.emotion_engine
+        local_vectors: List[EmotionVector] = []
+        for line in lines:
+            vec = emotion_engine.export_emotion_vector(line)
+            local_vectors.append(vec)
+
+        field = EmotionFieldEngine(window=4)
+        smoothed_vectors = field.smooth(local_vectors)
+        result["_emotion_dynamic"] = [v.to_dict() for v in smoothed_vectors]
+
         line_count = max(len(lines), 1)
         palette_items = [
             str(item).lower()

--- a/studiocore/emotion_field.py
+++ b/studiocore/emotion_field.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import List
+from studiocore.emotion_profile import EmotionVector
+
+
+class EmotionFieldEngine:
+    """
+    Smooths emotional spikes across lines (rolling window) to prevent chaos.
+    Produces a safe emotional field used by BPM/Genre/Vocal engines.
+    """
+
+    def __init__(self, window: int = 4) -> None:
+        self.window = window
+
+    def smooth(self, vectors: List[EmotionVector]) -> List[EmotionVector]:
+        if not vectors:
+            return []
+
+        smoothed = []
+        for i in range(len(vectors)):
+            start = max(0, i - self.window + 1)
+            window = vectors[start : i + 1]
+            avg = EmotionVector.average(window)
+            smoothed.append(avg)
+        return smoothed


### PR DESCRIPTION
## Summary
- add EmotionFieldEngine module to smooth per-line emotion vectors and expose averaged fields
- extend emotion and vocal pipelines to export vectors, smooth local emotions, and attach dynamic traces to analysis results
- introduce gentle emotional influences for BPM microshifts, genre scoring, and vocal timbre selection

## Testing
- python -m compileall studiocore

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f81d12aa8833290f57486248a6b8e)