### PR TITLE
Add emotion map engine

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -48,6 +48,7 @@ from .text_utils import (
 )
 from .user_override_manager import UserOverrideManager, UserOverrides
 from .emotion_profile import EmotionVector
+from studiocore.emotion_map import EmotionMapEngine
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -364,6 +365,13 @@ class StudioCoreV6:
         emotion_payload = self._merge_semantic_hints(emotion_payload, semantic_hints.get("emotion", {}))
 
         smoothed_vectors: list[EmotionVector] = []
+
+        try:
+            emap = EmotionMapEngine()
+            emotion_map_output = emap.build_map(smoothed_vectors)
+            result["_emotion_map"] = emotion_map_output
+        except Exception:
+            result["_emotion_map"] = {"wave": [], "global": "#000000"}
 
         try:
             from studiocore.emotion_profile import EmotionAggregator

--- a/studiocore/emotion_map.py
+++ b/studiocore/emotion_map.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import List
+
+from studiocore.emotion_profile import EmotionVector
+
+
+class EmotionMapEngine:
+    """
+    Converts smoothed emotional vectors into a visual color gradient.
+    Produces a color wave (#RRGGBB) for each line and a global gradient summary.
+    """
+
+    def __init__(self):
+        pass
+
+    def _map_value(self, x: float) -> int:
+        # clamp to 0–255
+        return max(0, min(255, int((x + 1) / 2 * 255)))
+
+    def vector_to_color(self, v: EmotionVector) -> str:
+        """
+        Convert EmotionVector → color hex.
+        valence  → red / blue
+        arousal → brightness
+        pain    → darkness shift
+        """
+        r = self._map_value(v.valence)
+        g = self._map_value(1.0 - v.pain)
+        b = self._map_value(-v.valence)
+
+        # brightness shift from arousal
+        brightness = v.arousal * 0.4
+        r = int(r * (0.8 + brightness))
+        g = int(g * (0.8 + brightness))
+        b = int(b * (0.8 + brightness))
+
+        return f"#{r:02X}{g:02X}{b:02X}"
+
+    def build_map(self, vectors: List[EmotionVector]) -> dict:
+        """
+        Produce:
+        - per-line color wave
+        - global average color
+        """
+        if not vectors:
+            return {"wave": [], "global": "#000000"}
+
+        wave = [self.vector_to_color(v) for v in vectors]
+
+        # compute global average color
+        avg_r = sum(int(c[1:3], 16) for c in wave) // len(wave)
+        avg_g = sum(int(c[3:5], 16) for c in wave) // len(wave)
+        avg_b = sum(int(c[5:7], 16) for c in wave) // len(wave)
+
+        global_color = f"#{avg_r:02X}{avg_g:02X}{avg_b:02X}"
+
+        return {
+            "wave": wave,
+            "global": global_color,
+        }


### PR DESCRIPTION
## Summary
- add new EmotionMapEngine to translate emotion vectors into color gradients
- integrate emotion map generation into the v6 analysis result with safe fallback

## Testing
- python -m compileall studiocore *(fails: existing syntax error in studiocore/symbiosis_audit.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8430dc7883329fbd89f44e2178c3)