### PR TITLE
Add color engine adapter for color waves

### DIFF
--- a/studiocore/color_engine_adapter.py
+++ b/studiocore/color_engine_adapter.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class ColorResolution:
+    colors: List[str]
+    source: str  # "tlp_rules" / "emotion_map" / "fallback"
+
+
+class ColorEngineAdapter:
+    """
+    Лёгкая адаптация ColorEngine к результату анализа:
+    — читает result["tlp"] и result["emotion"]
+    — создает color_wave: список hex-цветов
+    — не вмешивается в внутреннюю работу ColorEngine
+
+    Это прослойка: безопасна, не хранит состояния, не ломает пайплайн.
+    """
+
+    def resolve_color_wave(self, result: Dict[str, Any]) -> ColorResolution:
+        tlp = result.get("tlp", {}) or {}
+        emo = result.get("emotion", {}) or {}
+
+        # --- Значения по умолчанию ---
+        truth = float(tlp.get("truth", 0.0))
+        love = float(tlp.get("love", 0.0))
+        pain = float(tlp.get("pain", 0.0))
+
+        # Основные эмоциональные коэффициенты
+        hate = float(emo.get("anger", 0.0))
+        sadness = float(emo.get("sadness", 0.0))
+        joy = float(emo.get("joy", 0.0))
+        awe = float(emo.get("awe", 0.0))
+        fear = float(emo.get("fear", 0.0))
+
+        # --- Цветовые базовые правила (упрощённая версия) ---
+        # Боль / Печаль → синий → тёмный серый
+        if pain > 0.6 or sadness > 0.6:
+            return ColorResolution(
+                colors=["#0A1F44", "#2F4F4F", "#000000"],
+                source="tlp_rules",
+            )
+
+        # Гнев / Ненависть → чёрный → красный → чёрный
+        if hate > 0.7:
+            return ColorResolution(
+                colors=["#000000", "#8B0000", "#000000"],
+                source="emotion_map",
+            )
+
+        # Любовь → красный → розовый → белый
+        if love > 0.6 or joy > 0.6:
+            return ColorResolution(
+                colors=["#FF0000", "#FF69B4", "#FFFFFF"],
+                source="tlp_rules",
+            )
+
+        # Awe / mystic → бирюза → серебро → тень
+        if awe > 0.6:
+            return ColorResolution(
+                colors=["#008080", "#C0C0C0", "#2F4F4F"],
+                source="emotion_map",
+            )
+
+        # Fear → тёмно-фиолетовый → чёрный
+        if fear > 0.6:
+            return ColorResolution(
+                colors=["#2A0038", "#000000"],
+                source="emotion_map",
+            )
+
+        # --- Fallback (если эмоция непонятна) ---
+        return ColorResolution(
+            colors=["#222222", "#555555"],
+            source="fallback",
+        )

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -14,6 +14,7 @@ from dataclasses import asdict
 from typing import Any, Dict, Iterable, List, Sequence
 
 from .bpm_engine import BPMEngine
+from .color_engine_adapter import ColorEngineAdapter
 from .emotion_field import EmotionFieldEngine
 from .emotion_profile import EmotionVector
 from .rde_engine import RhythmDynamicsEmotionEngine
@@ -78,6 +79,7 @@ class StudioCoreV6:
         self.section_parser = SectionParser(self.text_engine)
         self.emotion_engine = EmotionEngine()
         self.color_engine = ColorEmotionEngine()
+        self.color_adapter = ColorEngineAdapter()
         self.vocal_engine = VocalEngine()
         self.breathing_engine = BreathingEngine()
         self.bpm_engine = BPMEngine()
@@ -1062,6 +1064,19 @@ class StudioCoreV6:
             result,
             applied_overrides=applied_overrides,
         )
+
+        # --- COLOR ENGINE ADAPTER ---
+        color_res = self.color_adapter.resolve_color_wave(result)
+
+        style_block = result.get("style") or {}
+        if not isinstance(style_block, dict):
+            style_block = {}
+
+        style_block.setdefault("color_wave", color_res.colors)
+        style_block.setdefault("color_source", color_res.source)
+
+        result["style"] = style_block
+
         suno_annotations = self.suno_engine.build_suno_safe_annotations(
             sections,
             {

--- a/tests/test_color_engine_adapter.py
+++ b/tests/test_color_engine_adapter.py
@@ -1,0 +1,19 @@
+def test_color_engine_adapter_basic():
+    from studiocore.color_engine_adapter import ColorEngineAdapter
+
+    adapter = ColorEngineAdapter()
+
+    # Сильная боль → синий спектр
+    res = adapter.resolve_color_wave({
+        "tlp": {"truth": 0, "love": 0, "pain": 0.9},
+        "emotion": {"sadness": 0.85},
+    })
+    assert "#0A1F44" in res.colors
+    assert res.source in ("tlp_rules", "emotion_map", "fallback")
+
+    # Гнев → черно-красная волна
+    res2 = adapter.resolve_color_wave({
+        "tlp": {"truth": 0, "love": 0, "pain": 0.2},
+        "emotion": {"anger": 0.9},
+    })
+    assert "#8B0000" in res2.colors


### PR DESCRIPTION
## Summary
- add a ColorEngineAdapter that maps tlp/emotion signals to color waves
- wire the adapter into StudioCoreV6 style block
- add basic adapter test coverage

## Testing
- python -m pytest tests/test_color_engine_adapter.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8e5f453083329b4e5ad2b8daf26e)