### PR TITLE
Add dynamic emotion-driven genre bias routing

### DIFF
--- a/studiocore/dynamic_emotion_engine.py
+++ b/studiocore/dynamic_emotion_engine.py
@@ -1,0 +1,64 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+"""DynamicEmotionEngine v1.0.
+
+This adapter normalises emotional readings into a 7-axis vector that can be
+used by downstream biasing logic.  It wraps the existing high-level
+``EmotionEngine`` heuristics to avoid duplicating lexicon logic while exposing
+an explicit ``emotion_profile`` interface for the new dynamic genre router.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .logical_engines import EmotionEngine
+from .emotion import TruthLovePainEngine
+
+
+class DynamicEmotionEngine:
+    """Bridge between heuristic emotion detection and the new 7-axis profile."""
+
+    AXES = ("joy", "sadness", "anger", "fear", "awe", "love", "pain")
+
+    def __init__(
+        self,
+        emotion_engine: EmotionEngine | None = None,
+        tlp_engine: TruthLovePainEngine | None = None,
+    ) -> None:
+        self._emotion_engine = emotion_engine or EmotionEngine()
+        self._tlp_engine = tlp_engine or TruthLovePainEngine()
+
+    def emotion_profile(self, text: str) -> Dict[str, float]:
+        """Return a normalised 7-axis emotion vector.
+
+        Falls back to a uniform neutral vector when no signal is present to
+        prevent downstream consumers from crashing.
+        """
+
+        text = text or ""
+        emotion_scores = self._emotion_engine.emotion_detection(text) or {}
+        tlp_scores = self._tlp_engine.analyze(text) if text.strip() else {}
+
+        raw_vector = {
+            "joy": float(emotion_scores.get("joy", 0.0)),
+            "sadness": float(emotion_scores.get("sadness", 0.0)),
+            "anger": float(emotion_scores.get("anger", 0.0)),
+            "fear": float(emotion_scores.get("fear", 0.0)),
+            "awe": float(emotion_scores.get("awe", 0.0)),
+            "love": float(tlp_scores.get("love", 0.0)),
+            "pain": float(tlp_scores.get("pain", 0.0)),
+        }
+
+        total = sum(raw_vector.values())
+        if total <= 0:
+            neutral_value = round(1.0 / len(self.AXES), 3)
+            return {axis: neutral_value for axis in self.AXES}
+
+        return {axis: round(max(score, 0.0) / total, 4) for axis, score in raw_vector.items()}
+
+
+__all__ = ["DynamicEmotionEngine"]

--- a/studiocore/emotion_genre_matrix.py
+++ b/studiocore/emotion_genre_matrix.py
@@ -1,0 +1,83 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+"""Emotion→Genre bias matrix (Variant A: Emotion is stronger than text)."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+_GENRES = (
+    "rock_metal",
+    "hip_hop",
+    "jazz",
+    "edm",
+    "orchestral",
+    "chanson",
+    "gothic",
+    "folk",
+    "pop",
+)
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def compute_genre_bias(emotion_vector: Dict[str, float]) -> Dict[str, float]:
+    """Translate a 7-axis emotion vector into macro-genre biases.
+
+    Biases are normalised to ``[0.0, 1.0]`` and start from a neutral baseline of
+    ``1.0``.  Variant A rules intentionally allow strong emotional signals to
+    dominate textual routing.
+    """
+
+    bias = {genre: 1.0 for genre in _GENRES}
+    vector = emotion_vector or {}
+
+    anger = float(vector.get("anger", 0.0))
+    sadness = float(vector.get("sadness", 0.0))
+    awe = float(vector.get("awe", 0.0))
+    joy = float(vector.get("joy", 0.0))
+    pain = float(vector.get("pain", 0.0))
+    love = float(vector.get("love", 0.0))
+
+    # anger ↑ metal/industrial/hip-hop, ↓ jazz/folk/pop
+    bias["rock_metal"] += 0.6 * anger
+    bias["hip_hop"] += 0.5 * anger
+    bias["jazz"] -= 0.4 * anger
+    bias["folk"] -= 0.3 * anger
+    bias["pop"] -= 0.3 * anger
+
+    # sadness ↑ gothic/darkwave/neofolk, ↓ EDM/pop
+    bias["gothic"] += 0.55 * sadness
+    bias["folk"] += 0.25 * sadness
+    bias["edm"] -= 0.35 * sadness
+    bias["pop"] -= 0.25 * sadness
+
+    # awe ↑ orchestral/cinematic, ↓ hip-hop/edm
+    bias["orchestral"] += 0.65 * awe
+    bias["hip_hop"] -= 0.25 * awe
+    bias["edm"] -= 0.2 * awe
+
+    # joy ↑ pop/funk/electronic, ↓ gothic/doom
+    bias["pop"] += 0.55 * joy
+    bias["edm"] += 0.35 * joy
+    bias["gothic"] -= 0.4 * joy
+
+    # pain ↑ darkwave/gothic, ↓ pop
+    bias["gothic"] += 0.5 * pain
+    bias["pop"] -= 0.45 * pain
+
+    # love ↑ ballad/folk, ↓ metal
+    bias["folk"] += 0.4 * love
+    bias["chanson"] += 0.2 * love
+    bias["rock_metal"] -= 0.35 * love
+
+    normalized = {genre: round(_clamp(value), 3) for genre, value in bias.items()}
+    return normalized
+
+
+__all__ = ["compute_genre_bias"]

--- a/tests/test_emotion_bias_matrix.py
+++ b/tests/test_emotion_bias_matrix.py
@@ -1,0 +1,25 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+import math
+
+from studiocore.emotion_genre_matrix import compute_genre_bias
+
+
+def test_compute_genre_bias_neutral_vector():
+    bias = compute_genre_bias({})
+
+    assert all(math.isclose(val, 1.0) for val in bias.values())
+
+
+def test_compute_genre_bias_variant_a_rules():
+    vector = {"anger": 0.6, "sadness": 0.3, "awe": 0.1}
+    bias = compute_genre_bias(vector)
+
+    assert bias["rock_metal"] >= bias["jazz"]
+    assert bias["gothic"] > bias["edm"]
+    assert bias["orchestral"] >= bias["hip_hop"]
+    assert all(0.0 <= val <= 1.0 for val in bias.values())
+


### PR DESCRIPTION
## Summary
- add DynamicEmotionEngine to derive 7-axis emotion profiles and map them to Variant A genre biases
- inject emotion-aware biasing into the v6 analysis pipeline and genre router while respecting user overrides
- extend regression coverage for emotion bias computation and FakeUserEngine state resets

## Testing
- python -m pytest tests/test_emotion_bias_matrix.py tests/test_fake_user_engine.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f906835a88332aa577430b80b6b1f)