### PR TITLE
Add phrase-level emotion packet scaffolding

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -308,7 +308,10 @@ class StudioCoreV6:
         emotion_profile = self.emotion_engine.emotion_detection(text)
         emotion_curve = self.emotion_engine.emotion_intensity_curve(text)
         dynamic_emotion_profile = self.dynamic_emotion_engine.emotion_profile(text)
-        section_intel_payload = self.section_intelligence.analyze(text, sections, emotion_curve)
+        self._emotion_engine.reset_phrase_packets()
+        section_intel_payload = self.section_intelligence.analyze(
+            text, sections, emotion_curve, emotion_engine=self._emotion_engine
+        )
         structure_context["section_intelligence"] = section_intel_payload
         structure_context["emotion_profile"] = dict(emotion_profile)
         structure_context["emotion_profile_axes7"] = dict(dynamic_emotion_profile)
@@ -1089,6 +1092,7 @@ class StudioCoreV6:
                 "style": style_payload,
                 "commands": command_payload,
                 "annotations": annotations,
+                "phrase_packets": section_intel_payload.get("phrase_packets", []),
                 "semantic_hints": semantic_hints,
                 "auto_context": structure_context,
                 "instrument_dynamics": instrument_dynamics_payload,
@@ -1180,6 +1184,7 @@ class StudioCoreV6:
         merged["zero_pulse"] = payload.get("zero_pulse", {})
         merged["bpm"] = payload.get("bpm", {})
         merged["semantic_hints"] = payload.get("semantic_hints", {})
+        merged["phrase_packets"] = payload.get("phrase_packets", [])
         merged["auto_context"] = payload.get("auto_context", {})
         merged["instrument_dynamics"] = payload.get("instrument_dynamics", {})
         merged["tlp"] = payload.get("tlp", {})

--- a/studiocore/emotion.py
+++ b/studiocore/emotion.py
@@ -13,6 +13,7 @@ import logging
 
 from studiocore.emotion_profile import EmotionVector, EmotionAggregator
 from studiocore.emotion_dictionary_extended import EmotionLexiconExtended
+from studiocore.structures import PhraseEmotionPacket
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -244,6 +245,7 @@ class EmotionEngine:
         self.auto_analyzer = AutoEmotionalAnalyzer()
         self._model = load_emotion_model()
         self._base_emotions = self._collect_base_emotions()
+        self._phrase_packets: list[PhraseEmotionPacket] = []
 
     def _collect_base_emotions(self) -> list[str]:
         clusters = self._model.get("clusters", {})
@@ -251,6 +253,29 @@ class EmotionEngine:
         for cluster in clusters.values():
             emotions.extend(cluster.get("emotions", []))
         return sorted(set(emotions))
+
+    def reset_phrase_packets(self) -> None:
+        """Reset the internal phrase packet buffer."""
+
+        self._phrase_packets = []
+
+    def get_phrase_packets(self) -> list[PhraseEmotionPacket]:
+        """Expose collected phrase packets for downstream consumers."""
+
+        return list(self._phrase_packets)
+
+    def analyze_phrase(self, phrase: str) -> PhraseEmotionPacket:
+        """Placeholder phrase-level analyzer (weights applied later)."""
+
+        packet = PhraseEmotionPacket(
+            phrase=phrase,
+            emotions={},
+            weight=1.0,
+            impact_zone="unknown",
+            semantic_role="phrase",
+        )
+        self._phrase_packets.append(packet)
+        return packet
 
     def build_raw_emotion_vector(self, text: str) -> Dict[str, float]:
         """Build normalized raw emotion scores (0..1) for atomic emotions."""

--- a/studiocore/structures.py
+++ b/studiocore/structures.py
@@ -1,0 +1,21 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+class PhraseEmotionPacket:
+    def __init__(self, phrase: str, emotions: dict, weight: float, impact_zone: str, semantic_role: str):
+        self.phrase = phrase
+        self.emotions = emotions
+        self.weight = weight
+        self.impact_zone = impact_zone
+        self.semantic_role = semantic_role
+
+    def to_dict(self):
+        return {
+            "phrase": self.phrase,
+            "emotions": self.emotions,
+            "weight": self.weight,
+            "impact_zone": self.impact_zone,
+            "semantic_role": self.semantic_role,
+        }

--- a/studiocore/text_utils.py
+++ b/studiocore/text_utils.py
@@ -31,6 +31,7 @@ ZERO_WIDTH_RE = re.compile(r"[\u200B\u200C\u200D\u2060\uFEFF]")
 # Многоточие и тире → к единому виду
 ELLIPSIS_RE = re.compile(r"\.{3,}")
 DASH_RE = re.compile(r"[–—-]{2,}")  # цепочки тире/дефисов
+PHRASE_BOUNDARY_RE = re.compile(r"[.!?…]+|\n")
 
 
 def _normalize_typography(line: str) -> str:
@@ -180,6 +181,20 @@ def flatten_sections_to_lines(sections: List[Dict[str, Any]]) -> List[str]:
     for s in sections:
         out.extend(s.get("lines", []))
     return out
+
+
+def extract_phrases_from_section(section_text: str) -> List[str]:
+    """Simple heuristic phrase splitter for a section payload."""
+
+    if not section_text:
+        return []
+
+    phrases: List[str] = []
+    for raw in PHRASE_BOUNDARY_RE.split(section_text):
+        phrase = raw.strip()
+        if phrase:
+            phrases.append(phrase)
+    return phrases
 
 # === v16: ИСПРАВЛЕНИЕ ImportError ===
 # Эта функция была в monolith_v4_3_1.py, но monolith v6 вызывает ее отсюда.


### PR DESCRIPTION
## Summary
- introduce PhraseEmotionPacket data structure for phrase-level emotional data
- add placeholder phrase analysis hooks and propagate phrase packets through section intelligence and core pipeline
- provide section phrase extraction helper and include phrase packet payloads in final results

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9a2771448332ac36db9f5491c0da)