### PR TITLE
Add SectionEmotionWave aggregation

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1093,6 +1093,7 @@ class StudioCoreV6:
                 "commands": command_payload,
                 "annotations": annotations,
                 "phrase_packets": section_intel_payload.get("phrase_packets", []),
+                "section_emotions": section_intel_payload.get("section_emotions", []),
                 "semantic_hints": semantic_hints,
                 "auto_context": structure_context,
                 "instrument_dynamics": instrument_dynamics_payload,
@@ -1197,6 +1198,7 @@ class StudioCoreV6:
         merged["fanf"] = payload.get("fanf", {})
         merged["style_prompt"] = payload.get("style_prompt")
         merged["summary"] = payload.get("style", {}).get("prompt") or payload.get("summary") or ""
+        merged["section_emotions"] = payload.get("section_emotions", [])
         merged.pop("_overrides_applied", None)
         return merged
 

--- a/studiocore/structures.py
+++ b/studiocore/structures.py
@@ -19,3 +19,23 @@ class PhraseEmotionPacket:
             "impact_zone": self.impact_zone,
             "semantic_role": self.semantic_role,
         }
+
+
+class SectionEmotionWave:
+    def __init__(self, section, tlp_mean, cluster_peak, intensity, emotional_shape, hot_phrases):
+        self.section = section
+        self.tlp_mean = tlp_mean
+        self.cluster_peak = cluster_peak
+        self.intensity = intensity
+        self.emotional_shape = emotional_shape
+        self.hot_phrases = hot_phrases
+
+    def to_dict(self):
+        return {
+            "section": self.section,
+            "tlp_mean": self.tlp_mean,
+            "cluster_peak": self.cluster_peak,
+            "intensity": self.intensity,
+            "emotional_shape": self.emotional_shape,
+            "hot_phrases": self.hot_phrases,
+        }

--- a/tests/test_section_emotion_wave.py
+++ b/tests/test_section_emotion_wave.py
@@ -1,0 +1,29 @@
+from studiocore.section_intelligence import SectionIntelligence
+from studiocore.emotion import EmotionEngine
+
+
+def test_section_emotion_wave_basic():
+    text = """[Verse]
+    Как лошадь, загнанная в мыле
+    Любовь светает в тишине
+    """
+    engine = EmotionEngine()
+    si = SectionIntelligence(engine=engine)
+    result = si.parse(text)
+    waves = result.get("section_emotions")
+    assert waves and isinstance(waves, list)
+    wave = waves[0]
+    assert "tlp_mean" in wave
+    assert "cluster_peak" in wave
+    assert "intensity" in wave
+
+
+def test_section_wave_detects_spike():
+    text = """[Chorus]
+    Убей! Убей их всех!
+    Тихий шепот любви...
+    """
+    engine = EmotionEngine()
+    si = SectionIntelligence(engine=engine)
+    waves = si.parse(text)["section_emotions"]
+    assert waves[0]["emotional_shape"] in ("spike", "rising")


### PR DESCRIPTION
## Summary
- add SectionEmotionWave data structure and expose section-level emotion wave output
- extend SectionIntelligence to aggregate phrase packets per section and integrate with StudioCore v6
- add tests covering section emotion wave basics and spike detection

## Testing
- pytest tests/test_section_emotion_wave.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9d8a57288332b20ec28b6e99ba87)