### PR TITLE
Add global emotion curve and dynamic bias hints

### DIFF
--- a/studiocore/emotion_curve.py
+++ b/studiocore/emotion_curve.py
@@ -1,0 +1,164 @@
+"""Global emotion curve construction utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+
+SECTION_ORDER = ["intro", "verse", "prechorus", "chorus", "bridge", "outro"]
+
+
+@dataclass
+class GlobalEmotionCurve:
+    sections: List[Dict]
+    global_tlp: Dict[str, float]
+    dominant_cluster: str | None
+    peaks: List[int]
+    valleys: List[int]
+    dynamic_bias: Dict[str, object]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "sections": self.sections,
+            "global_tlp": self.global_tlp,
+            "dominant_cluster": self.dominant_cluster,
+            "peaks": self.peaks,
+            "valleys": self.valleys,
+            "dynamic_bias": self.dynamic_bias,
+        }
+
+
+def _ordered_sections(section_emotions: Sequence[Dict]) -> List[Dict]:
+    order_index = {name: idx for idx, name in enumerate(SECTION_ORDER)}
+    augmented: List[Dict] = []
+    for idx, section in enumerate(section_emotions):
+        section_name = str(section.get("section", "")).lower()
+        augmented.append((order_index.get(section_name, len(order_index) + idx), idx, dict(section)))
+
+    augmented.sort(key=lambda item: (item[0], item[1]))
+    ordered = []
+    for new_idx, (_, _, section) in enumerate(augmented):
+        section["index"] = new_idx
+        ordered.append(section)
+    return ordered
+
+
+def _mean(values: Iterable[float]) -> float:
+    total = 0.0
+    count = 0
+    for value in values:
+        try:
+            total += float(value)
+            count += 1
+        except (TypeError, ValueError):
+            continue
+    return total / count if count else 0.0
+
+
+def _compute_global_tlp(sections: Sequence[Dict]) -> Dict[str, float]:
+    truth_vals = [section.get("tlp_mean", {}).get("truth", 0.0) for section in sections]
+    love_vals = [section.get("tlp_mean", {}).get("love", 0.0) for section in sections]
+    pain_vals = [section.get("tlp_mean", {}).get("pain", 0.0) for section in sections]
+    return {
+        "truth": _mean(truth_vals),
+        "love": _mean(love_vals),
+        "pain": _mean(pain_vals),
+    }
+
+
+def _dominant_cluster(sections: Sequence[Dict]) -> str | None:
+    frequency: Dict[str, int] = {}
+    intensity_sum: Dict[str, float] = {}
+
+    for section in sections:
+        cluster = section.get("cluster_peak")
+        if not cluster:
+            continue
+        frequency[cluster] = frequency.get(cluster, 0) + 1
+        try:
+            intensity = float(section.get("intensity", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            intensity = 0.0
+        intensity_sum[cluster] = intensity_sum.get(cluster, 0.0) + intensity
+
+    if not frequency:
+        return None
+
+    max_freq = max(frequency.values())
+    candidates = [cluster for cluster, freq in frequency.items() if freq == max_freq]
+    if len(candidates) == 1:
+        return candidates[0]
+
+    best_cluster = None
+    best_intensity = -1.0
+    for cluster in candidates:
+        avg_intensity = intensity_sum.get(cluster, 0.0) / max(frequency.get(cluster, 1), 1)
+        if avg_intensity > best_intensity:
+            best_cluster = cluster
+            best_intensity = avg_intensity
+    return best_cluster
+
+
+def _peaks_and_valleys(intensities: Sequence[float]) -> tuple[List[int], List[int]]:
+    if not intensities:
+        return [], []
+    safe_values = [float(value or 0.0) for value in intensities]
+    max_intensity = max(safe_values)
+    min_intensity = min(safe_values)
+    peak_threshold = max_intensity - 0.05
+    valley_threshold = min_intensity + 0.05
+    peaks = [idx for idx, value in enumerate(safe_values) if value >= peak_threshold]
+    valleys = [idx for idx, value in enumerate(safe_values) if value <= valley_threshold]
+    return peaks, valleys
+
+
+def _compute_dynamic_bias(global_tlp: Dict[str, float], cluster: str | None) -> Dict[str, object]:
+    bias = {"bpm_delta": 0.0, "key_hint": None, "genre_hint": None}
+    cluster_key = (cluster or "").lower()
+    truth = float(global_tlp.get("truth", 0.0) or 0.0)
+    love = float(global_tlp.get("love", 0.0) or 0.0)
+    pain = float(global_tlp.get("pain", 0.0) or 0.0)
+
+    cluster_to_genre = {
+        "rage": "metal_adaptive",
+        "despair": "dark_rock",
+        "fear": "dark_rock",
+        "tender": "lyrical_ballad",
+        "hope": "lyrical_ballad",
+        "contemplative": "poetic_narrative",
+        "narrative": "poetic_narrative",
+    }
+
+    if pain > love and pain > truth and cluster_key in {"rage", "despair", "fear"}:
+        bias["bpm_delta"] = 7.5
+        bias["key_hint"] = "minor"
+    elif love > pain and love > truth and cluster_key in {"tender", "hope"}:
+        bias["bpm_delta"] = -6.0
+        bias["key_hint"] = "major"
+    elif truth > pain and truth > love and cluster_key in {"contemplative", "narrative"}:
+        bias["bpm_delta"] = -3.0
+        bias["key_hint"] = None
+
+    bias["genre_hint"] = cluster_to_genre.get(cluster_key)
+    return bias
+
+
+def build_global_emotion_curve(section_emotions: Sequence[Dict]) -> GlobalEmotionCurve:
+    ordered_sections = _ordered_sections(section_emotions)
+    global_tlp = _compute_global_tlp(ordered_sections)
+    dominant_cluster = _dominant_cluster(ordered_sections)
+    intensities = [section.get("intensity", 0.0) for section in ordered_sections]
+    peaks, valleys = _peaks_and_valleys(intensities)
+    dynamic_bias = _compute_dynamic_bias(global_tlp, dominant_cluster)
+    return GlobalEmotionCurve(
+        sections=ordered_sections,
+        global_tlp=global_tlp,
+        dominant_cluster=dominant_cluster,
+        peaks=peaks,
+        valleys=valleys,
+        dynamic_bias=dynamic_bias,
+    )
+
+
+__all__ = ["GlobalEmotionCurve", "build_global_emotion_curve"]

--- a/tests/test_emotion_curve.py
+++ b/tests/test_emotion_curve.py
@@ -1,0 +1,55 @@
+from studiocore.emotion_curve import build_global_emotion_curve
+from studiocore.core_v6 import StudioCoreV6
+
+
+def test_emotion_curve_builds_from_sections():
+    sections = [
+        {
+            "section": "intro",
+            "tlp_mean": {"truth": 0.2, "love": 0.1, "pain": 0.7},
+            "cluster_peak": "rage",
+            "intensity": 0.9,
+            "emotional_shape": "spike",
+            "hot_phrases": ["Убей их всех"],
+        },
+        {
+            "section": "chorus",
+            "tlp_mean": {"truth": 0.3, "love": 0.2, "pain": 0.8},
+            "cluster_peak": "rage",
+            "intensity": 0.95,
+            "emotional_shape": "rising",
+            "hot_phrases": ["НАЧНИ С СЕБЯ"],
+        },
+    ]
+    curve = build_global_emotion_curve(sections)
+    data = curve.to_dict()
+    assert "global_tlp" in data
+    assert "dominant_cluster" in data
+    assert data["dominant_cluster"] == "rage"
+    assert "peaks" in data and data["peaks"]
+
+
+def test_dynamic_bias_applies_for_love():
+    sections = [
+        {
+            "section": "verse",
+            "tlp_mean": {"truth": 0.1, "love": 0.8, "pain": 0.1},
+            "cluster_peak": "tender",
+            "intensity": 0.6,
+            "emotional_shape": "flat",
+            "hot_phrases": ["Любовь! какой чаруйный звук!"],
+        }
+    ]
+    curve = build_global_emotion_curve(sections)
+    bias = curve.to_dict()["dynamic_bias"]
+    assert bias["bpm_delta"] < 0
+    assert bias["key_hint"] == "major"
+
+
+def test_core_exposes_emotion_curve():
+    core = StudioCoreV6()
+    text = "[Verse]\nКак лошадь, загнанная в мыле\nЛюбовь и боль сплетают мост"
+    result = core.analyze(text)
+    assert "emotion_curve" in result
+    assert "auto_context" in result
+    assert "dynamic_bias" in result["auto_context"]


### PR DESCRIPTION
## Summary
- add GlobalEmotionCurve helper to compute ordered sections, peaks, valleys, and dynamic bias hints
- integrate global emotion curve payload into StudioCoreV6 analyze output and auto_context
- add tests covering curve construction, bias calculation, and core exposure of dynamic bias hints

## Testing
- pytest tests/test_emotion_curve.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa11272588332987e78102f89f9fb)