### PR TITLE
Add emotion-driven Suno annotations

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -50,6 +50,7 @@ from .section_intelligence import SectionIntelligenceEngine
 from .suno_annotations import (
     SunoAnnotationEngine,
     _dominant_emotion,
+    build_suno_annotations,
     emotion_to_instruments,
     emotion_to_style,
     emotion_to_vocal,
@@ -1109,6 +1110,11 @@ class StudioCoreV6:
                 "genre_analysis": genre_analysis,
             }
         )
+        result["suno_annotation"] = build_suno_annotations(
+            text=text,
+            sections=section_intel_payload.get("section_emotions", []),
+            emotion_curve=curve_dict,
+        )
         fanf_analysis_payload = {
             "emotion": {"profile": emotion_profile, "curve": emotion_curve},
             "bpm": bpm_payload,
@@ -1197,6 +1203,7 @@ class StudioCoreV6:
         merged["instrument_dynamics"] = payload.get("instrument_dynamics", {})
         merged["tlp"] = payload.get("tlp", {})
         merged["suno_annotations"] = payload.get("suno_annotations", [])
+        merged["suno_annotation"] = payload.get("suno_annotation")
         merged["symbiosis"] = payload.get("symbiosis", {})
         merged["override_debug"] = payload.get("override_debug", {})
         merged["language"] = payload.get("language", payload.get("auto_context", {}).get("language"))

--- a/tests/test_suno_emotion_annotations.py
+++ b/tests/test_suno_emotion_annotations.py
@@ -1,0 +1,18 @@
+from studiocore.suno_annotations import build_suno_annotations
+
+
+def test_suno_emotion_adapter_basic():
+    curve = {
+        "dominant_cluster": "tender",
+        "global_tlp": {"truth": 0.1, "love": 0.8, "pain": 0.1},
+    }
+    sections = [
+        {"section": "verse", "intensity": 0.4, "hot_phrases": ["Любовь как тихий свет"]},
+        {"section": "chorus", "intensity": 0.9, "hot_phrases": ["Сгорит душа"]},
+    ]
+    ann = build_suno_annotations("..", sections, curve)
+    assert "vocal_profile" in ann
+    assert "instrumentation" in ann
+    assert "section_annotations" in ann
+    assert "chorus" in ann["section_annotations"]
+


### PR DESCRIPTION
## Summary
- add emotion-driven Suno adapter to build genre-agnostic annotations from emotion curves
- integrate generated annotation payload into the core v6 result
- add a basic unit test for the new Suno emotion annotation builder

## Testing
- pytest tests/test_suno_emotion_annotations.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa27de6348332b196e50dc4d05cc6)