### PR TITLE
Implement multimodal emotion matrix integration

### DIFF
--- a/studiocore/multimodal_emotion_matrix.py
+++ b/studiocore/multimodal_emotion_matrix.py
@@ -1,0 +1,173 @@
+from typing import Any, Dict, List
+
+
+class MultimodalEmotionMatrixV1:
+    """
+    Multimodal Emotional Matrix (M-E-M) v1.
+
+    Сводит в единый эмоционально-музыкальный профиль:
+    - phrase_emotions
+    - section_emotions (SectionEmotionWave)
+    - global_emotion_curve (GlobalEmotionCurve)
+    - tlp_profile (TLP Engine)
+    - dynamic_bias (emotion-driven BPM/KEY hints)
+    - genre_hint, bpm_hint, key_hint (от существующих движков)
+    - suno emotional annotations
+    """
+
+    def __init__(self, *, version: str = "v1") -> None:
+        self.version = version
+
+    def build_matrix(
+        self,
+        *,
+        phrase_emotions: List[dict],
+        section_emotions: List[dict],
+        global_curve: Dict[str, Any],
+        tlp_profile: Dict[str, float],
+        dynamic_bias: Dict[str, Any],
+        genre_hint: Any,
+        bpm_hint: Any,
+        key_hint: Any,
+        suno_annotation: Dict[str, Any],
+    ) -> Dict[str, Any]:
+
+        # Простая и безопасная агрегация без override пользовательских параметров.
+        # Все рекомендации = hints, которые могут быть использованы Suno или StudioCore.
+        # Никакого состояния — чистый stateless.
+
+        dominant = global_curve.get("dominant_cluster")
+        sections = global_curve.get("sections", [])
+
+        # Определение доминирующих эмоций
+        if tlp_profile:
+            t = tlp_profile.get("truth", 0.0)
+            l = tlp_profile.get("love", 0.0)
+            p = tlp_profile.get("pain", 0.0)
+            dominant_emotions = sorted(
+                [("truth", t), ("love", l), ("pain", p)],
+                key=lambda x: x[1],
+                reverse=True,
+            )
+        else:
+            dominant_emotions = []
+
+        # Рекомендации по жанру
+        if dominant == "rage":
+            genre_primary = "extreme_adaptive_rage"
+            sub = "dark_metal_core"
+        elif dominant == "despair":
+            genre_primary = "darkwave_cinematic"
+            sub = "gothic_melancholic"
+        elif dominant == "tender":
+            genre_primary = "lyrical_ballad"
+            sub = "neoclassical_soft"
+        elif dominant == "hope":
+            genre_primary = "ambient_orchestral"
+            sub = "light_neo"
+        elif dominant == "narrative":
+            genre_primary = "poetic_narrative"
+            sub = "acoustic_indie"
+        else:
+            genre_primary = "adaptive_hybrid"
+            sub = None
+
+        # BPM рекомендации
+        bpm_rec = bpm_hint or 120.0
+        if dynamic_bias:
+            bpm_delta = dynamic_bias.get("bpm_delta", 0.0)
+            bpm_rec = float(bpm_rec) + float(bpm_delta)
+
+        # Key рекомендации
+        key_mode = None
+        if dynamic_bias:
+            if dynamic_bias.get("key_hint") == "minor":
+                key_mode = "minor"
+            elif dynamic_bias.get("key_hint") == "major":
+                key_mode = "major"
+
+        # Вокал
+        primary_emotion = dominant_emotions[0][0] if dominant_emotions else None
+        if primary_emotion == "pain":
+            vok = {
+                "gender": "male",
+                "intensity_curve": [sec.get("intensity", 0) for sec in sections],
+                "notes": "distorted male low + aggressive fry layers",
+            }
+        elif primary_emotion == "love":
+            vok = {
+                "gender": "female",
+                "intensity_curve": [sec.get("intensity", 0) for sec in sections],
+                "notes": "soft airy female vocal, close mic",
+            }
+        elif primary_emotion == "truth":
+            vok = {
+                "gender": "male",
+                "intensity_curve": [sec.get("intensity", 0) for sec in sections],
+                "notes": "spoken baritone clarity",
+            }
+        else:
+            vok = {
+                "gender": "auto",
+                "intensity_curve": [sec.get("intensity", 0) for sec in sections],
+                "notes": "adaptive vocal blend",
+            }
+
+        # Инструменты
+        if primary_emotion == "pain":
+            inst = {
+                "core": ["distorted_guitars", "heavy_drums"],
+                "accent": ["sub_bass", "fry_noise"],
+                "texture": ["industrial_air"],
+            }
+        elif primary_emotion == "love":
+            inst = {
+                "core": ["piano", "cello"],
+                "accent": ["soft_pads"],
+                "texture": ["warm_reverb"],
+            }
+        elif primary_emotion == "truth":
+            inst = {
+                "core": ["acoustic_guitar"],
+                "accent": ["soft_percussion"],
+                "texture": ["narrative_space"],
+            }
+        else:
+            inst = {
+                "core": ["hybrid_base"],
+                "accent": [],
+                "texture": [],
+            }
+
+        return {
+            "version": self.version,
+            "tlp": tlp_profile,
+            "dominant_emotions": dominant_emotions,
+            "global_curve": global_curve,
+            "section_emotions": section_emotions,
+            "dynamic_bias": dynamic_bias,
+            "genre": {
+                "primary": genre_primary,
+                "subgenre": sub,
+                "confidence": 1.0,
+                "source": "emotion_matrix_v1",
+            },
+            "bpm": {
+                "recommended": bpm_rec,
+                "source": "emotion_matrix_v1",
+            },
+            "key": {
+                "recommended": key_hint,
+                "mode": key_mode,
+                "source": "emotion_matrix_v1",
+            },
+            "vocals": vok,
+            "instruments": inst,
+            "suno_emotion_annotations": suno_annotation,
+        }
+
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_fake_user_engine.py
+++ b/tests/test_fake_user_engine.py
@@ -76,6 +76,8 @@ def test_fake_user_emotion_and_genre(user):
         f"❌ summary missing for user={user['id']}"
     )
 
+    _assert_integrity(result)
+
     print(f"✅ OK: {user['id']} | emotion={emotion_name} | genre={genre}")
 
 
@@ -99,7 +101,24 @@ def test_fake_user_state_and_bias_reset():
         bpms.append(bpm_estimate)
         genres.append(genre)
 
+        _assert_integrity(res)
+
     assert len({json.dumps(b, sort_keys=True) for b in biases}) > 1, "❌ Bias values must differ across samples"
     numeric_bpms = {b for b in bpms if isinstance(b, (int, float))}
     assert len(numeric_bpms) > 1, "❌ BPM must reset per request"
     assert any(g != "edm" for g in genres), "❌ Genre must not default to EDM"
+
+
+def _assert_integrity(result: dict) -> None:
+    matrix = result.get("emotion_matrix")
+    if matrix is not None:
+        assert isinstance(matrix, dict)
+        assert "genre" in matrix
+        assert "bpm" in matrix
+        assert "key" in matrix
+
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_multimodal_emotion_matrix.py
+++ b/tests/test_multimodal_emotion_matrix.py
@@ -1,0 +1,35 @@
+from studiocore.core_v6 import StudioCoreV6
+
+
+def test_matrix_rage():
+    text = "[Chorus]\nУбей их всех!\nНАЧНИ С СЕБЯ"
+    core = StudioCoreV6()
+    result = core.analyze(text)
+    m = result.get("emotion_matrix")
+    assert m
+    assert m["genre"]["primary"] != "edm"
+    assert m["bpm"]["recommended"] > 130
+
+
+def test_matrix_love():
+    text = "[Verse]\nЛюбовь как тихий свет\nСердце растает"
+    core = StudioCoreV6()
+    result = core.analyze(text)
+    m = result.get("emotion_matrix")
+    assert m
+    assert m["genre"]["primary"] != "extreme_adaptive_rage"
+    assert m["tlp"]["love"] > m["tlp"]["pain"]
+
+
+def test_core_matrix_integrated():
+    text = "[Verse]\nКак лошадь, загнанная в мыле"
+    core = StudioCoreV6()
+    result = core.analyze(text)
+    assert "emotion_matrix" in result
+    assert isinstance(result["emotion_matrix"], dict)
+
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e


### PR DESCRIPTION
## Summary
- add MultimodalEmotionMatrixV1 module to aggregate emotional and musical hints
- integrate emotion matrix output into StudioCoreV6 analysis and Suno annotation hinting
- extend test coverage with new matrix scenarios and updated fake user checks

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa6b1b01083328f3db577c7227301)