### PR TITLE
Add signature blocks to StudioCore and tests

### DIFF
--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -284,3 +284,8 @@ if __name__ == "__main__":  # pragma: no cover - manual smoke-test only
             print(f"⚙️ Активные подсистемы: {', '.join(subsystems)}\n")
     except Exception as exc:
         print(f"❌ Ошибка инициализации: {exc}")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/adapter.py
+++ b/studiocore/adapter.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -180,3 +184,8 @@ def build_suno_prompt(
         )
         max_len = 5000 if prompt_variant == "full" else 1200
         return semantic_compress(base_prompt, max_len, preserve_last_line=True)
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/app.py
+++ b/studiocore/app.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 """
 StudioCore Internal Test Runner
@@ -48,3 +52,8 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/auto_integrator.py
+++ b/studiocore/auto_integrator.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -98,3 +102,8 @@ class AutoIntegrator:
 
 if __name__ == "__main__":
     AutoIntegrator().execute()
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/bpm_engine.py
+++ b/studiocore/bpm_engine.py
@@ -41,3 +41,8 @@ class BPMEngine(_CoreBPMEngine):
 
 
 __all__ = ["BPMEngine"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/color_engine_adapter.py
+++ b/studiocore/color_engine_adapter.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -77,3 +81,8 @@ class ColorEngineAdapter:
             colors=["#222222", "#555555"],
             source="fallback",
         )
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/config.py
+++ b/studiocore/config.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -75,3 +79,8 @@ def load_config(path: str = "studio_config.json") -> dict:
             json.dump(data, f, indent=2, ensure_ascii=False)
 
     return data
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 """StudioCore v6 compatibility wrapper.
 
 The implementation does not aim to be feature-complete.  Instead it provides a

--- a/studiocore/dynamic_emotion_engine.py
+++ b/studiocore/dynamic_emotion_engine.py
@@ -62,3 +62,8 @@ class DynamicEmotionEngine:
 
 
 __all__ = ["DynamicEmotionEngine"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion.py
+++ b/studiocore/emotion.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 """
 StudioCore Emotion Engines (v15 - Имена ИСПРАВЛЕНЫ)
@@ -456,3 +460,7 @@ class EmotionEngine:
             profile["legacy"] = legacy_context
         return profile
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_curve.py
+++ b/studiocore/emotion_curve.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 """Global emotion curve construction utilities."""
 
 from __future__ import annotations
@@ -162,3 +166,8 @@ def build_global_emotion_curve(section_emotions: Sequence[Dict]) -> GlobalEmotio
 
 
 __all__ = ["GlobalEmotionCurve", "build_global_emotion_curve"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_dictionary_extended.py
+++ b/studiocore/emotion_dictionary_extended.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -104,3 +108,8 @@ class EmotionLexiconExtended:
         base = high_hits * 0.3 + medium_hits * 0.15 + low_hits * 0.05
 
         return round(min(1.0, base + punctuation_bonus), 3)
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_engine.py
+++ b/studiocore/emotion_engine.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -134,3 +138,8 @@ class EmotionEngineV64:
             "tlp": tlp,
             "dominant_name": dominant,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_field.py
+++ b/studiocore/emotion_field.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from __future__ import annotations
 from typing import List
 from studiocore.emotion_profile import EmotionVector
@@ -23,3 +27,8 @@ class EmotionFieldEngine:
             avg = EmotionVector.average(window)
             smoothed.append(avg)
         return smoothed
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_genre_matrix.py
+++ b/studiocore/emotion_genre_matrix.py
@@ -81,3 +81,8 @@ def compute_genre_bias(emotion_vector: Dict[str, float]) -> Dict[str, float]:
 
 
 __all__ = ["compute_genre_bias"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_map.py
+++ b/studiocore/emotion_map.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from __future__ import annotations
 
 from typing import List
@@ -59,3 +63,8 @@ class EmotionMapEngine:
             "wave": wave,
             "global": global_color,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/emotion_profile.py
+++ b/studiocore/emotion_profile.py
@@ -88,3 +88,8 @@ class EmotionAggregator:
 
 
 # === END OF FILE ===
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/fallback.py
+++ b/studiocore/fallback.py
@@ -20,3 +20,8 @@ class StudioCoreFallback:
         raise RuntimeError(
             "⚠️ StudioCoreFallback: анализ недоступен — основное ядро не загружено."
         )
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/fanf_annotation.py
+++ b/studiocore/fanf_annotation.py
@@ -283,3 +283,7 @@ class FANFAnnotationEngine:
         section_line = " ".join(sections)
         return f"{cinematic_header} {resonance_header} {section_line} {choir_tag}"
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/frequency.py
+++ b/studiocore/frequency.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -104,3 +108,8 @@ class UniversalFrequencyEngine:
             "rns_index": rns_index,
             "safe_band_hz": safe_center
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/fusion_engine_v64.py
+++ b/studiocore/fusion_engine_v64.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -269,3 +273,8 @@ class FusionEngineV64:
         }
 
         return fusion_summary
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_matrix_extended.py
+++ b/studiocore/genre_matrix_extended.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 """Light-weight rule-based genre detector for StudioCore v6."""
 from __future__ import annotations
 
@@ -158,3 +162,8 @@ class GenreMatrixExtended(GenreMatrixEngine):
 
         engine = GenreWeightsEngine()
         return engine.infer_genre(feature_map)
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_meta_matrix.py
+++ b/studiocore/genre_meta_matrix.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -89,3 +93,8 @@ class GenreMetaMatrix:
         normalized = {d: v / total for d, v in raw_counts.items()}
 
         return normalized
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_registry.py
+++ b/studiocore/genre_registry.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -220,3 +224,8 @@ class GlobalGenreRegistry:
         }
 
     # Вспомогательные методы можно расширять позже
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_router.py
+++ b/studiocore/genre_router.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from __future__ import annotations
 
 # StudioCore Signature Block (Do Not Remove)
@@ -212,3 +216,8 @@ class DynamicGenreRouter:
         macro_genre = max(adjusted_scores.items(), key=lambda kv: kv[1])[0]
         reason = "dynamic_router_emotion_bias" if bias else "dynamic_router"
         return macro_genre, reason
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_routing_engine.py
+++ b/studiocore/genre_routing_engine.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -87,3 +91,8 @@ class GenreRoutingEngineV64:
             "subgenre": sub_genre,
             "suno_style": suno_style,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_universe.py
+++ b/studiocore/genre_universe.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -163,3 +167,8 @@ class GenreUniverse:
             "ethnic_music_schools": list(self.ethnic_music_schools),
             "hybrids": list(self.hybrids),
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_universe_adapter.py
+++ b/studiocore/genre_universe_adapter.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -91,3 +95,8 @@ class GenreUniverseAdapter:
             tags=[],
             source="fallback_minimal",
         )
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_universe_extended.py
+++ b/studiocore/genre_universe_extended.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -276,3 +280,8 @@ def build_global_genre_universe_v2() -> GenreUniverse:
 
 
 __all__ = ["build_global_genre_universe_v2"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_universe_loader.py
+++ b/studiocore/genre_universe_loader.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -18,3 +22,8 @@ def load_genre_universe():
 
 
 __all__ = ["load_genre_universe"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/genre_weights.py
+++ b/studiocore/genre_weights.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -260,3 +264,8 @@ class GenreWeightsEngine:
             return "lyrical_song"
 
         return selected
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/instrument.py
+++ b/studiocore/instrument.py
@@ -253,3 +253,8 @@ def instrument_rhythm_sync(
         "confidence": 0.65,
         "rationale": f"Rhythm profile suggests {groove} percussion bed.",
     }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/instrument_dynamics.py
+++ b/studiocore/instrument_dynamics.py
@@ -89,3 +89,8 @@ class InstrumentalDynamicsEngine:
             "zero_pulse": zero,
             "mapping": mapping,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/integrity.py
+++ b/studiocore/integrity.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -83,3 +87,8 @@ class IntegrityScanEngine:
             },
             "integrity_score": integrity_score,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/logger.py
+++ b/studiocore/logger.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 """
 StudioCore v5 — Централизованный конфигуратор логов. (v2 - TypeError ИСПРАВЛЕН)
@@ -77,3 +81,8 @@ def setup_logging(level=logging.INFO):
     log.info(f"🚀 Централизованное логирование (УРОВЕНЬ {logging.getLevelName(CURRENT_LOG_LEVEL)}) активировано.")
     log.info("=" * 50)
     _is_configured = True
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/logical_engines.py
+++ b/studiocore/logical_engines.py
@@ -1021,3 +1021,8 @@ class FinalCompiler:
         if not payload.get("style", {}).get("prompt"):
             issues.append("Style prompt missing")
         return {"issues": issues, "is_consistent": not issues}
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/lyrical_emotion.py
+++ b/studiocore/lyrical_emotion.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -72,3 +76,8 @@ class LyricalEmotionEngine:
             "lyrical_emotion_score": max(0.0, min(1.0, final_score)),
             "prefer_strict_boundary": prefer_strict_boundary,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/monolith_v4_3_1.py
+++ b/studiocore/monolith_v4_3_1.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 """
 StudioCore v4.3.11 — Monolith (v6 - Suno Аннотации)
@@ -602,3 +606,8 @@ class StudioCoreV5:
 # ==========================================================
 STUDIOCORE_VERSION = "v4.3.11"
 log.info(f"🔹 [StudioCore {STUDIOCORE_VERSION}] Monolith loaded (Section-Aware Duet Mode v2).")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/multimodal_emotion_matrix.py
+++ b/studiocore/multimodal_emotion_matrix.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from typing import Any, Dict, List
 
 

--- a/studiocore/rde_engine.py
+++ b/studiocore/rde_engine.py
@@ -69,3 +69,8 @@ class RhythmDynamicsEmotionEngine:
 
 
 __all__ = ["RDESnapshot", "RhythmDynamicsEmotionEngine"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/rhythm.py
+++ b/studiocore/rhythm.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 """Rhythm analysis engine for StudioCore v6.
 
@@ -439,3 +443,8 @@ __all__ = [
     "resolve_global_bpm",
     "calc_tension",
 ]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/section_intelligence.py
+++ b/studiocore/section_intelligence.py
@@ -308,3 +308,8 @@ class SectionIntelligence:
         self.engine.reset_phrase_packets()
         result = self._engine.analyze(text, sections, emotion_curve=None, emotion_engine=self.engine)
         return result
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/section_parser.py
+++ b/studiocore/section_parser.py
@@ -77,3 +77,8 @@ class SectionParser:
 
 
 __all__ = ["SectionParser", "SectionParseResult"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/sections.py
+++ b/studiocore/sections.py
@@ -60,3 +60,8 @@ class SectionTagAnalyzer:
         core_result["bpm"] = bpm
         core_result["annotations"] = annotations
         return core_result
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/spiritual_emotion_map.py
+++ b/studiocore/spiritual_emotion_map.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -96,3 +100,8 @@ class SpiritualEmotionMap:
                     self.axes[key] *= self.axes["spiritual_relevance"]
 
         return self.axes
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/structures.py
+++ b/studiocore/structures.py
@@ -39,3 +39,8 @@ class SectionEmotionWave:
             "emotional_shape": self.emotional_shape,
             "hot_phrases": self.hot_phrases,
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/style.py
+++ b/studiocore/style.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -286,3 +290,8 @@ except NameError:
         log.info("🎨 [StyleMatrix alias] PatchedStyleMatrix → StyleMatrix (compat mode active)")
     except Exception as e:
         log.warning(f"⚠️ [StyleMatrix alias] failed: {e}")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/symbiosis_audit.py
+++ b/studiocore/symbiosis_audit.py
@@ -158,3 +158,8 @@ class SymbiosisAudit:
 if __name__ == "__main__":
     SymbiosisAudit().execute()
 EOF
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/text_utils.py
+++ b/studiocore/text_utils.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -246,3 +250,8 @@ def translate_text_for_analysis(text: str, language: str) -> Tuple[str, bool]:
         "translate_text_for_analysis is not configured; returning source text for language '%s'", language
     )
     return text, False
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/tlp_engine.py
+++ b/studiocore/tlp_engine.py
@@ -40,3 +40,8 @@ class TruthLovePainEngine(_TruthLovePainEngine):
 
 
 __all__ = ["TruthLovePainEngine"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/tone.py
+++ b/studiocore/tone.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -186,3 +190,8 @@ class ToneSyncEngine:
             return False
         normalized = paragraph.strip().lower()
         return any(normalized.startswith(marker) for marker in self.RIFT_MARKERS)
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/ui_builder.py
+++ b/studiocore/ui_builder.py
@@ -19,3 +19,8 @@ def coerce_sections(text_obj: Any) -> List[Any]:
     if isinstance(sections, Iterable) and not isinstance(sections, (str, bytes)):
         return list(sections)
     return [sections] if sections else []
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/user_override_manager.py
+++ b/studiocore/user_override_manager.py
@@ -152,3 +152,8 @@ class UserOverrideManager:
                 "structure_hints": self.overrides.structure_hints,
             },
         }
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/studiocore/vocals.py
+++ b/studiocore/vocals.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 # -*- coding: utf-8 -*-
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
@@ -307,3 +311,8 @@ class VocalProfileRegistry:
         
         log.debug(f"Возврат: Vox={vox}, Inst={inst}, Form={vocal_form}")
         return vox, inst, vocal_form
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,8 @@ import sys
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_bpm_engine.py
+++ b/tests/test_bpm_engine.py
@@ -15,3 +15,8 @@ def test_bpm_engine_describe_returns_curve():
     assert payload["estimate"] > 0
     assert isinstance(payload["curve"], list)
     assert "poly_rhythm" in payload
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_color_engine_adapter.py
+++ b/tests/test_color_engine_adapter.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 def test_color_engine_adapter_basic():
     from studiocore.color_engine_adapter import ColorEngineAdapter
 
@@ -17,3 +21,8 @@ def test_color_engine_adapter_basic():
         "emotion": {"anger": 0.9},
     })
     assert "#8B0000" in res2.colors
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_core_v6_pipeline.py
+++ b/tests/test_core_v6_pipeline.py
@@ -26,3 +26,8 @@ def test_core_v6_analyze_produces_expected_sections():
     assert result["bpm"].get("emotion_map", {}).get("target_bpm")
     assert result.get("fanf", {}).get("annotated_text_fanf")
     assert "choir_active" in result.get("fanf", {})
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_dynamic_genre_router.py
+++ b/tests/test_dynamic_genre_router.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from studiocore.genre_router import DynamicGenreRouter
 
 
@@ -20,3 +24,8 @@ def test_dynamic_genre_router_basic_sanity():
     macro2, reason2 = router.route(base)
     assert macro2 == "jazz"
     assert reason2 == "user_override"
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_emotion_bias_matrix.py
+++ b/tests/test_emotion_bias_matrix.py
@@ -23,3 +23,7 @@ def test_compute_genre_bias_variant_a_rules():
     assert bias["orchestral"] >= bias["hip_hop"]
     assert all(0.0 <= val <= 1.0 for val in bias.values())
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_emotion_curve.py
+++ b/tests/test_emotion_curve.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from studiocore.emotion_curve import build_global_emotion_curve
 from studiocore.core_v6 import StudioCoreV6
 
@@ -53,3 +57,8 @@ def test_core_exposes_emotion_curve():
     assert "emotion_curve" in result
     assert "auto_context" in result
     assert "dynamic_bias" in result["auto_context"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_emotion_model_v1.py
+++ b/tests/test_emotion_model_v1.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 import math
 
 from studiocore.emotion import EmotionEngine, load_emotion_model
@@ -45,3 +49,8 @@ def test_integration_aggression_and_love():
     assert any(love_profile.get("genre_scores", {}).get(name, 0) >= 0 for name in soft_genres)
     assert 70 <= love_profile.get("bpm", 0) <= 110
     assert str(love_profile.get("key", {}).get("scale", "")).startswith("major")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_fanf_engine.py
+++ b/tests/test_fanf_engine.py
@@ -30,3 +30,8 @@ def test_fanf_choir_disabled_for_intimate_text():
     annotation = engine.build_annotations("soft whisper under blankets", ["intro"], analysis)
     assert annotation.choir_active is False
     assert "No choir" in annotation.annotated_text_suno
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_genre_universe_adapter.py
+++ b/tests/test_genre_universe_adapter.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 def test_genre_universe_adapter_smoke():
     from studiocore.genre_universe_adapter import GenreUniverseAdapter
 
@@ -9,3 +13,8 @@ def test_genre_universe_adapter_smoke():
     assert isinstance(res.subgenre, str)
     assert isinstance(res.tags, list)
     assert res.source in ("universe_v2", "fallback_table", "fallback_minimal")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_genre_universe_extended.py
+++ b/tests/test_genre_universe_extended.py
@@ -34,3 +34,8 @@ def test_resolve_and_detect_domain():
 
     hybrid_info = universe.detect_domain("tribal_techno")
     assert hybrid_info["type"] in {"hybrid", "music", "edm"}
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_gothic_genre_routing.py
+++ b/tests/test_gothic_genre_routing.py
@@ -38,3 +38,8 @@ def test_gothic_material_not_classified_as_edm():
 
     sections = result.get("structure", {}).get("sections", [])
     assert sections and not (len(sections) == 1 and "BODY" in sections)
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,3 +25,8 @@ def test_loader_diagnostics_shape():
     assert diag.monolith_version == MONOLITH_VERSION
     assert diag.active in {None, "v6", "v5", "monolith", "fallback"}
     assert STUDIOCORE_VERSION.startswith("v6")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_multimodal_emotion_matrix.py
+++ b/tests/test_multimodal_emotion_matrix.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from studiocore.core_v6 import StudioCoreV6
 
 

--- a/tests/test_overrides_once.py
+++ b/tests/test_overrides_once.py
@@ -42,3 +42,7 @@ def test_apply_user_overrides_once_idempotent_and_recalculates_bpm_curve():
         == adjustments_first["bpm"]["estimate"]
     )
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_phrase_emotion_engine.py
+++ b/tests/test_phrase_emotion_engine.py
@@ -45,3 +45,8 @@ def test_phrase_engine_neutral_on_empty():
     assert 0.0 <= tlp["pain"] <= 1.0
     assert 0.0 <= tlp["love"] <= 1.0
     assert packet.weight <= 0.2
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_rde_engine.py
+++ b/tests/test_rde_engine.py
@@ -28,3 +28,8 @@ def test_rde_engine_compose_returns_snapshot():
     assert snapshot.target_bpm == BPM_PAYLOAD["estimate"]
     assert "pads" in (snapshot.palette or [])
     assert snapshot.breath_sync == BREATH["sync_score"]
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_section_emotion_wave.py
+++ b/tests/test_section_emotion_wave.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from studiocore.section_intelligence import SectionIntelligence
 from studiocore.emotion import EmotionEngine
 
@@ -27,3 +31,8 @@ def test_section_wave_detects_spike():
     si = SectionIntelligence(engine=engine)
     waves = si.parse(text)["section_emotions"]
     assert waves[0]["emotional_shape"] in ("spike", "rising")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_section_parser.py
+++ b/tests/test_section_parser.py
@@ -26,3 +26,8 @@ def test_section_parser_detects_annotations():
     )
     assert adjustments["bpm"] >= 120
     assert adjustments["annotations"] == result.annotations
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_style_genre_integration.py
+++ b/tests/test_style_genre_integration.py
@@ -36,3 +36,8 @@ def test_lyrical_features_pick_lyric_forms():
     })
 
     assert genre in engine._genres_for_domain("lyrical")
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_suno_emotion_annotations.py
+++ b/tests/test_suno_emotion_annotations.py
@@ -1,3 +1,7 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
 from studiocore.suno_annotations import build_suno_annotations
 
 
@@ -16,3 +20,7 @@ def test_suno_emotion_adapter_basic():
     assert "section_annotations" in ann
     assert "chorus" in ann["section_annotations"]
 
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e

--- a/tests/test_tlp_engine.py
+++ b/tests/test_tlp_engine.py
@@ -15,3 +15,8 @@ def test_tlp_engine_describe_returns_dominant_axis():
     assert {"truth", "love", "pain"}.issubset(profile.keys())
     assert profile["dominant_axis"] in profile
     assert "balance" in profile
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e


### PR DESCRIPTION
## Summary
- add the required StudioCore Signature Block to the beginning and end of all StudioCore Python modules
- add the same signature block to all test modules to ensure repository-wide compliance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa8fe9074833284b88885d64bc81c)