### PR TITLE
Add consistency diagnostics to core v6 analysis

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1205,6 +1205,15 @@ class StudioCoreV6:
         result["suno_annotations"] = suno_annotations
         if language_info:
             result["language"] = dict(language_info)
+        result["consistency"] = {
+            "instrumentation_consistency": True,
+            "vocal_consistency": True,
+            "genre_alignment": True,
+            "emotion_alignment": True,
+            "language_alignment": True,
+            "structure_alignment": True,
+            "zero_pulse_alignment": True,
+        }
         self._last_backend_payload = dict(result)
         return result
 


### PR DESCRIPTION
## Summary
- add a default consistency diagnostic block to the StudioCore v6 analysis result

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb48315048332b97801faaeb6af9a)