### PR TITLE
Fix suno annotations structure

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1130,11 +1130,12 @@ class StudioCoreV6:
             suno_annotation=result.get("suno_annotation", {}),
         )
         result["emotion_matrix"] = matrix
-        result["suno_annotation"] = build_suno_annotations(
+        suno_annotation_payload = build_suno_annotations(
             text=text,
             sections=section_intel_payload.get("section_emotions", []),
             emotion_curve=curve_dict,
         )
+        result["suno_annotation"] = suno_annotation_payload
         fanf_analysis_payload = {
             "emotion": {"profile": emotion_profile, "curve": emotion_curve},
             "bpm": bpm_payload,
@@ -1189,7 +1190,7 @@ class StudioCoreV6:
 
         result["style"] = style_block
 
-        suno_annotations = self.suno_engine.build_suno_safe_annotations(
+        suno_safe_annotations = self.suno_engine.build_suno_safe_annotations(
             sections,
             {
                 "bpm": result.get("bpm", {}),
@@ -1202,7 +1203,10 @@ class StudioCoreV6:
                 "emotion_matrix": result.get("emotion_matrix"),
             },
         )
-        result["suno_annotations"] = suno_annotations
+        result["suno_annotations"] = {
+            **suno_annotation_payload,
+            "safe_annotations": suno_safe_annotations,
+        }
         if language_info:
             result["language"] = dict(language_info)
         result["consistency"] = {
@@ -1232,7 +1236,7 @@ class StudioCoreV6:
         merged["auto_context"] = payload.get("auto_context", {})
         merged["instrument_dynamics"] = payload.get("instrument_dynamics", {})
         merged["tlp"] = payload.get("tlp", {})
-        merged["suno_annotations"] = payload.get("suno_annotations", [])
+        merged["suno_annotations"] = payload.get("suno_annotations", {})
         merged["suno_annotation"] = payload.get("suno_annotation")
         merged["symbiosis"] = payload.get("symbiosis", {})
         merged["override_debug"] = payload.get("override_debug", {})


### PR DESCRIPTION
## Summary
- build the suno annotations payload from the emotion-driven adapter and include safe annotations
- ensure merged results expose a structured suno annotations block instead of a list

## Testing
- python - <<'PY'
from studiocore.core_v6 import StudioCoreV6
import json, sys

print("\n[TEST] Running extended diagnostics test for Esenin…\n")

text = """
Вы помните,
Вы всё, конечно, помните,
Как я стоял,
Приблизившись к стене,
Взволнованно ходили вы по комнате
И что-то резкое
В лицо бросали мне.
"""

core = StudioCoreV6()
result = core.analyze(text, preferred_gender="auto")

warnings = []

# === CHECK 1: Section headers ===
sections = result.get("structure", {}).get("sections", [])
if not sections:
    warnings.append("❌ sections missing")
else:
    print("[OK] Sections detected:", sections)

# === CHECK 2: Emotion Curve ===
emotion_curve = result.get("emotion_curve")
required_curve_fields = {"global_tlp", "dominant_cluster", "sections"}
if not (isinstance(emotion_curve, dict) and required_curve_fields.issubset(emotion_curve.keys())):
    warnings.append("❌ emotion_curve missing data")
else:
    print("[OK] Emotion curve structure ✓")
    print("    dominant cluster:", emotion_curve.get("dominant_cluster"))
    print("    global TLP:", emotion_curve.get("global_tlp"))

# === CHECK 3: Diagnostics integration ===
diag = result.get("diagnostics", {})
if not isinstance(diag, dict):
    warnings.append("❌ diagnostics missing")
else:
    print("[OK] Diagnostics present")
    print("    BPM:", diag.get("bpm"))
    print("    Tonality:", diag.get("tonality"))
    print("    Vocal:", diag.get("vocal"))

# === CHECK 4: Suno annotations ===
suno = result.get("suno_annotations")
required = {"style", "vocal_profile", "instrumentation", "section_annotations"}
if not (isinstance(suno, dict) and required.issubset(suno.keys())):
    warnings.append("❌ suno_annotations incomplete")
else:
    print("[OK] Suno emotion annotations ✓")

# === PRINT RESULT SUMMARY ===
print("\n=== FINAL RESULT ===")
print(json.dumps({
    "sections": sections,
    "dominant_cluster": emotion_curve.get("dominant_cluster") if emotion_curve else None,
    "tlp": emotion_curve.get("global_tlp") if emotion_curve else None,
    "warnings": warnings,
}, ensure_ascii=False, indent=2))

if warnings:
    print("\n⚠️ WARNINGS FOUND — review needed")
else:
    print("\n✅ ALL CHECKS PASSED — Esenin block is correct")
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb6fbe38883329612830074ef423b)