### PR TITLE
Handle missing instrument dynamics in Suno annotations

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1189,13 +1189,23 @@ class StudioCoreV6:
 
         result["style"] = style_block
 
+        instrumentation_block = result.get("instrumentation")
+        if not isinstance(instrumentation_block, dict):
+            instrumentation_block = {}
+
+        dynamics_block = (
+            instrument_dynamics_payload
+            if isinstance(instrument_dynamics_payload, dict)
+            else {}
+        )
+
         suno_annotations = self.suno_engine.build_suno_safe_annotations(
             sections,
             {
                 "bpm": result.get("bpm", {}),
                 "instrumentation": {
-                    "palette": result.get("instrumentation", {}).get("palette"),
-                    "fractures": instrument_dynamics_payload.get("fractures"),
+                    "palette": instrumentation_block.get("palette"),
+                    "fractures": dynamics_block.get("fractures"),
                 },
                 "vocal": result.get("vocal", {}),
                 "commands": command_payload,

--- a/tests/test_core_v6_pipeline.py
+++ b/tests/test_core_v6_pipeline.py
@@ -27,6 +27,18 @@ def test_core_v6_analyze_produces_expected_sections():
     assert result.get("fanf", {}).get("annotated_text_fanf")
     assert "choir_active" in result.get("fanf", {})
 
+
+def test_core_v6_handles_missing_instrument_dynamics():
+    core = StudioCoreV6()
+
+    core.instrument_dynamics.map_instruments_to_structure = (
+        lambda *args, **kwargs: None
+    )
+
+    result = core.analyze("Тестовый текст без инструментальных динамик")
+
+    assert isinstance(result.get("suno_annotations"), list)
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27


### PR DESCRIPTION
## Summary
- guard Suno annotation construction against missing instrument dynamics data
- add regression coverage ensuring analyze tolerates absent instrument dynamics without crashing

## Testing
- pytest -q --disable-warnings --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbbc8a0dc83278740a8186e8fd080)