### PR TITLE
Ensure Suno annotations handle missing instrumentation dynamics

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1192,12 +1192,14 @@ class StudioCoreV6:
         instrumentation_block = result.get("instrumentation")
         if not isinstance(instrumentation_block, dict):
             instrumentation_block = {}
+        result["instrumentation"] = instrumentation_block
 
         dynamics_block = (
             instrument_dynamics_payload
             if isinstance(instrument_dynamics_payload, dict)
             else {}
         )
+        result["instrument_dynamics"] = dynamics_block
 
         suno_annotations = self.suno_engine.build_suno_safe_annotations(
             sections,
@@ -1211,7 +1213,7 @@ class StudioCoreV6:
                 "commands": command_payload,
                 "emotion_matrix": result.get("emotion_matrix"),
             },
-        )
+        ) or []
         result["suno_annotations"] = suno_annotations
         if language_info:
             result["language"] = dict(language_info)

--- a/tests/test_core_v6_pipeline.py
+++ b/tests/test_core_v6_pipeline.py
@@ -35,9 +35,9 @@ def test_core_v6_handles_missing_instrument_dynamics():
         lambda *args, **kwargs: None
     )
 
-    result = core.analyze("Тестовый текст без инструментальных динамик")
+    result = core.analyze("Тестовый текст…")
 
-    assert isinstance(result.get("suno_annotations"), list)
+    assert isinstance(result["suno_annotations"], list)
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)


### PR DESCRIPTION
## Summary
- normalize instrumentation and dynamics blocks before building Suno annotations to keep dictionaries stable
- guarantee Suno annotations default to a list even when dynamics mapping returns nothing
- adjust test to validate handling of missing instrument dynamics input

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbdf3127c8327a85a63e1bff6506b)