### PR TITLE
Add emotion matrix fallbacks for diagnostics

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1129,6 +1129,34 @@ class StudioCoreV6:
             key_hint=result.get("tone", {}).get("key"),
             suno_annotation=result.get("suno_annotation", {}),
         )
+        # === Inject emotion_matrix_v1 hints (fallback) ===
+        em_bpm = matrix.get("bpm", {}) if isinstance(matrix, dict) else {}
+        em_key = matrix.get("key", {}) if isinstance(matrix, dict) else {}
+        em_voc = matrix.get("vocals", {}) if isinstance(matrix, dict) else {}
+
+        # If legacy BPM is missing, use emotion_matrix_v1 recommended BPM
+        if not result.get("bpm") or not result["bpm"].get("estimate"):
+            result["bpm"] = {
+                "estimate": em_bpm.get("recommended"),
+                "source": em_bpm.get("source", "emotion_matrix_v1"),
+            }
+
+        # If tonality missing, use emotion_matrix_v1 key_hint
+        if not result.get("tone") or not result["tone"].get("key"):
+            result["tone"] = {
+                "key": em_key.get("recommended"),
+                "mode": em_key.get("mode"),
+                "source": em_key.get("source", "emotion_matrix_v1"),
+            }
+
+        # If vocal diagnostics missing, use matrix vocals
+        if not result.get("vocal"):
+            result["vocal"] = {
+                "gender": em_voc.get("gender"),
+                "notes": em_voc.get("notes"),
+                "intensity_curve": em_voc.get("intensity_curve"),
+                "source": "emotion_matrix_v1",
+            }
         result["emotion_matrix"] = matrix
         result["suno_annotation"] = build_suno_annotations(
             text=text,

--- a/studiocore/suno_annotations.py
+++ b/studiocore/suno_annotations.py
@@ -253,6 +253,13 @@ class SunoAnnotationEngine:
 
     def _prepare_diagnostics(self, diagnostics: Dict[str, Any] | None) -> Dict[str, Any]:
         prepared = dict(diagnostics or {})
+        if isinstance(diagnostics, dict):
+            if isinstance(diagnostics.get("bpm"), dict):
+                prepared["bpm"] = dict(diagnostics.get("bpm", {}))
+            if isinstance(diagnostics.get("tone"), dict):
+                prepared["tonality"] = dict(diagnostics.get("tone", {}))
+            if isinstance(diagnostics.get("vocal"), dict):
+                prepared["vocal"] = dict(diagnostics.get("vocal", {}))
         emotion_matrix = prepared.get("emotion_matrix") if isinstance(prepared.get("emotion_matrix"), dict) else None
 
         if emotion_matrix:

--- a/tests/test_suno_emotion_annotations.py
+++ b/tests/test_suno_emotion_annotations.py
@@ -2,7 +2,7 @@
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27
 # Hash: 22ae-df91-bc11-6c7e
-from studiocore.suno_annotations import build_suno_annotations
+from studiocore.suno_annotations import SunoAnnotationEngine, build_suno_annotations
 
 
 def test_suno_emotion_adapter_basic():
@@ -19,6 +19,27 @@ def test_suno_emotion_adapter_basic():
     assert "instrumentation" in ann
     assert "section_annotations" in ann
     assert "chorus" in ann["section_annotations"]
+
+
+def test_prepare_diagnostics_fills_from_emotion_matrix():
+    engine = SunoAnnotationEngine()
+    diagnostics = {
+        "emotion_matrix": {
+            "bpm": {"recommended": 132, "source": "emotion_matrix_v1"},
+            "key": {"recommended": "F#", "mode": "minor", "source": "emotion_matrix_v1"},
+            "vocals": {
+                "gender": "female",
+                "notes": ["airy", "soft"],
+                "intensity_curve": [0.1, 0.2],
+            },
+        }
+    }
+
+    prepared = engine._prepare_diagnostics(diagnostics)
+
+    assert prepared["bpm"]["estimate"] == 132
+    assert prepared["tonality"]["key"] == "minor"
+    assert prepared["vocal"]["style"] == "airy, soft"
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)


### PR DESCRIPTION
## Summary
- add emotion_matrix_v1-derived fallbacks for BPM, tone, and vocal diagnostics in the v6 analysis flow
- propagate BPM, tonality, and vocal fields into Suno diagnostics preparation when available
- add a unit test to confirm diagnostics consume emotion_matrix_v1 BPM/key/vocal hints

## Testing
- pytest tests/test_suno_emotion_annotations.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc5745e108327a080a53d8b912197)