### PR TITLE
Add diagnostics fallback and test for StudioCoreV6

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -1255,6 +1255,19 @@ class StudioCoreV6:
             "zero_pulse_alignment": True,
         }
         self._last_backend_payload = dict(result)
+
+        # === SAFE DIAGNOSTICS FALLBACK ===
+        emotion_matrix = result.get("emotion_matrix", {})
+        diagnostics = {
+            "bpm": result.get("bpm", {}),
+            "tonality": result.get("tone", {}),
+            "vocal": result.get("vocal", {}),
+            "sections": result.get("sections", []),
+            "emotion_matrix_source": emotion_matrix.get("version", None),
+        }
+
+        result["diagnostics"] = diagnostics
+
         return result
 
     def _finalize_result(self, payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -1285,6 +1298,7 @@ class StudioCoreV6:
         merged["summary"] = payload.get("style", {}).get("prompt") or payload.get("summary") or ""
         merged["section_emotions"] = payload.get("section_emotions", [])
         merged["emotion_curve"] = payload.get("emotion_curve", {})
+        merged["diagnostics"] = payload.get("diagnostics", {})
         merged.pop("_overrides_applied", None)
         return merged
 

--- a/tests/test_core_v6_pipeline.py
+++ b/tests/test_core_v6_pipeline.py
@@ -39,6 +39,13 @@ def test_core_v6_handles_missing_instrument_dynamics():
 
     assert isinstance(result["suno_annotations"], list)
 
+
+def test_core_v6_provides_diagnostics():
+    core = StudioCoreV6()
+    result = core.analyze("Тестовый текст")
+    assert "diagnostics" in result
+    assert isinstance(result["diagnostics"], dict)
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27


### PR DESCRIPTION
## Summary
- add diagnostics fallback data to StudioCoreV6 analysis results
- include diagnostics in finalized results
- add regression test to ensure diagnostics presence

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc75f92088327891c99f732532135)