### PR TITLE
Warn once when translation is disabled

### DIFF
--- a/studiocore/text_utils.py
+++ b/studiocore/text_utils.py
@@ -15,6 +15,9 @@ from typing import Any, Dict, List, Tuple
 
 log = logging.getLogger(__name__)
 
+# Internal guard to avoid spamming the log with repeated translation warnings.
+_translation_warning_emitted = False
+
 # Разрешённые символы (для подсказок и визуальных тегов; сами по себе не используются для фильтрации)
 PUNCTUATION_SAFE = set(list(",.;:!?…—–()[]\"'“”‘’*•‧·_/|"))
 EMOJI_SAFE = set(list("♡♥❤❥❣☀☁☂☮☯☾☽★☆✨⚡☼⚔⚖⚙⚗⚛✝✟✞✡☠☢☣❄☃"))
@@ -246,9 +249,14 @@ def translate_text_for_analysis(text: str, language: str) -> Tuple[str, bool]:
     выполняется, `was_translated` устанавливается в ``False`` честно.
     """
 
-    log.warning(
-        "translate_text_for_analysis is not configured; returning source text for language '%s'", language
-    )
+    global _translation_warning_emitted
+
+    if not _translation_warning_emitted:
+        log.warning(
+            "translate_text_for_analysis is not configured; returning source text for language '%s'",
+            language,
+        )
+        _translation_warning_emitted = True
     return text, False
 
 # StudioCore Signature Block (Do Not Remove)

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,19 @@
+import logging
+
+from studiocore.text_utils import translate_text_for_analysis
+import studiocore.text_utils as text_utils
+
+
+def test_translate_text_for_analysis_warns_once(caplog):
+    text_utils._translation_warning_emitted = False
+
+    with caplog.at_level(logging.WARNING):
+        translate_text_for_analysis("пример", "ru")
+        translate_text_for_analysis("ещё", "ru")
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "translate_text_for_analysis is not configured" in record.message
+    ]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary
- emit the translate_text_for_analysis warning only once to prevent log spam
- add a test that guards the one-time warning behavior

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc7ed30a48327b16fe42ba63b514f)