### PR TITLE
Ensure diagnostics leverage emotion matrix fallback data

### DIFF
--- a/tests/test_suno_emotion_annotations.py
+++ b/tests/test_suno_emotion_annotations.py
@@ -41,6 +41,29 @@ def test_prepare_diagnostics_fills_from_emotion_matrix():
     assert prepared["tonality"]["key"] == "minor"
     assert prepared["vocal"]["style"] == "airy, soft"
 
+
+def test_esenin_diagnostics_not_none():
+    from studiocore.core_v6 import StudioCoreV6
+
+    text = (
+        "Вы помните,\n"
+        "Вы всё, конечно, помните,\n"
+        "Как я стоял,\n"
+        "Приблизившись к стене,\n"
+        "Взволнованно ходили вы по комнате\n"
+        "И что-то резкое\n"
+        "В лицо бросали мне."
+    )
+    core = StudioCoreV6()
+    result = core.analyze(text, preferred_gender="auto")
+    diagnostics = result.get("diagnostics", {})
+
+    assert isinstance(diagnostics, dict)
+    assert diagnostics.get("bpm") is not None
+    assert diagnostics.get("tonality") is not None
+    assert diagnostics.get("vocal") is not None
+    assert diagnostics.get("emotion_matrix") is not None
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27


### PR DESCRIPTION
## Summary
- initialize diagnostics early in the v6 pipeline and enrich them with emotion matrix fallbacks for bpm, tonality, vocal, and instrumentation without overriding legacy values
- normalize emotion matrix usage for Suno annotations and resolve tone/tonality key hint conflicts while always attaching diagnostics
- add a regression test ensuring diagnostics are populated for long-form text analysis

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920448920e88327a3588c6f0608a97b)