### PR TITLE
Refactor StudioCore state handling and diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,6 +115,8 @@ CORE_RELOAD_REQUIRED = False
 LAST_CORE_ERROR: str | None = None
 CORE_SUCCESSFUL_INITS = 0
 MAX_INPUT_LENGTH = 60000
+AUTO_HEALTHCHECK = os.getenv("AUTO_HEALTHCHECK")
+HEALTH_THREAD_ENABLED = (AUTO_HEALTHCHECK or "0").lower() in ("1", "true", "yes") or os.getenv("DISABLE_SELF_CHECK", "1") == "0"
 
 
 def _ensure_core_module(force_reload: bool = False):
@@ -334,8 +336,8 @@ def auto_core_check():
     log.debug("[Self-Check] Поток запущен, ожидание 5с...")
     time.sleep(5)
 
-    if os.environ.get("DISABLE_SELF_CHECK", "1") != "0":
-        log.info("[Self-Check] Проверка отключена (DISABLE_SELF_CHECK!=0).")
+    if not HEALTH_THREAD_ENABLED:
+        log.info("[Self-Check] Автопроверка отключена по умолчанию (AUTO_HEALTHCHECK=0).")
         return
 
     try:
@@ -357,10 +359,10 @@ def auto_core_check():
         log.error(f"❌ Self-Check ошибка: {e}")
 
 
-if os.environ.get("DISABLE_SELF_CHECK", "1") == "0":
+if HEALTH_THREAD_ENABLED:
     threading.Thread(target=auto_core_check, daemon=True).start()
 else:
-    log.info("[Self-Check] Автопроверка отключена по умолчанию (DISABLE_SELF_CHECK=1).")
+    log.info("[Self-Check] Автопроверка отключена по умолчанию (AUTO_HEALTHCHECK=0).")
 
 
 # === 8. АНАЛИЗ ТЕКСТА (Gradio) ===

--- a/studiocore/__init__.py
+++ b/studiocore/__init__.py
@@ -20,7 +20,7 @@ from .fallback import StudioCoreFallback
 
 # Version fingerprint linked to FINGERPRINT: StudioCore-FP-2025-SB-9fd72e27
 # NOTE: This is the canonical public version; config.py mirrors this value for consistency.
-STUDIOCORE_VERSION = "v6.4.0-protected"
+STUDIOCORE_VERSION = "v6.4-maxi"
 DEFAULT_MONOLITH = "monolith_v4_3_1"
 DEFAULT_LOADER_ORDER = ("v6", "v5", "monolith", "fallback")
 

--- a/studiocore/adapter.py
+++ b/studiocore/adapter.py
@@ -113,6 +113,7 @@ def build_suno_prompt(
     """
     log.debug(f"Вызов функции: build_suno_prompt (Variant: {prompt_variant})")
 
+    style_data = dict(style_data or {})
     genre = style_data.get("genre", "adaptive emotional")
     style = style_data.get("style", "free-form tonal flow")
     key = style_data.get("key", "auto")

--- a/studiocore/config.py
+++ b/studiocore/config.py
@@ -17,7 +17,7 @@ import os
 import json
 
 # Canonical StudioCore version. Legacy labels kept for backward compatibility only.
-STUDIOCORE_VERSION = "v6.4.0-protected"
+STUDIOCORE_VERSION = "v6.4-maxi"
 # Deprecated: retained for older tooling that still expects the adaptive label.
 # STUDIOCORE_VERSION_LEGACY = "v4.3.1-adaptive"
 

--- a/studiocore/logical_engines.py
+++ b/studiocore/logical_engines.py
@@ -77,7 +77,12 @@ class TextStructureEngine:
     def __init__(self) -> None:
         self._section_metadata: List[Dict[str, Any]] = []
 
+    def reset(self) -> None:
+        """Clear cached structural metadata to avoid cross-request bleed."""
+        self._section_metadata = []
+
     def auto_section_split(self, text: str) -> List[str]:
+        self.reset()
         structured = extract_sections(text)
         sections: List[str] = []
         metadata: List[Dict[str, Any]] = []
@@ -95,7 +100,14 @@ class TextStructureEngine:
             )
         if not sections and text.strip():
             sections = [text.strip()]
-        self._section_metadata = metadata
+        self._section_metadata = [
+            {
+                "tag": item.get("tag"),
+                "lines": list(item.get("lines", [])),
+                "line_count": item.get("line_count", len(item.get("lines", []))),
+            }
+            for item in metadata
+        ]
         return sections
 
     def _resolve_sections(self, text: str, sections: Sequence[str] | None) -> List[str]:
@@ -134,6 +146,9 @@ class TextStructureEngine:
                 "tag": item.get("tag"),
                 "lines": list(item.get("lines", [])),
                 "line_count": item.get("line_count", len(item.get("lines", []))),
+                "strict_boundary": item.get("strict_boundary"),
+                "lyrical_density": item.get("lyrical_density"),
+                "rde_emotion_hint": item.get("rde_emotion_hint"),
             }
             for item in self._section_metadata
         ]


### PR DESCRIPTION
## Summary
- reset analysis state across engines, sections, and FANF outputs to prevent leakage between runs
- harden emotional, TLP, frequency, and diagnostic outputs with neutral fallbacks, genre source tagging, and cleaned vocal fusion
- synchronize version identifiers and default-disable health checks while keeping Suno prompt variables defined

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692063cd9a308327a0c2f75c2966a0f5)