### PR TITLE
Centralize emotion color mapping

### DIFF
--- a/studiocore/color_engine_adapter.py
+++ b/studiocore/color_engine_adapter.py
@@ -8,6 +8,73 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 
+KEY_COLOR_PALETTE: Dict[str, str] = {
+    "red": "#FF0000",
+    "orange-red": "#FF4500",
+    "golden": "#DAA520",
+    "amber": "#FFBF00",
+    "yellow": "#FFFF00",
+    "green": "#2E8B57",
+    "turquoise": "#40E0D0",
+    "blue": "#1E90FF",
+    "indigo": "#4B0082",
+    "violet": "#8A2BE2",
+    "magenta": "#FF00FF",
+    "crimson": "#DC143C",
+}
+
+
+EMOTION_COLOR_MAP: Dict[str, List[str]] = {
+    "truth": [KEY_COLOR_PALETTE["indigo"], "#6C1BB1"],
+    "love": ["#FF0000", "#FF69B4", "#FFFFFF"],
+    "pain": ["#0A1F44", "#2F4F4F", "#000000"],
+    "joy": [KEY_COLOR_PALETTE["golden"], "#FFD54F", "#FFF8E1"],
+    "sadness": ["#0A1F44", KEY_COLOR_PALETTE["blue"], "#2F4F4F"],
+    "anger": ["#8B0000", KEY_COLOR_PALETTE["crimson"], "#000000"],
+    "fear": ["#2A0038", "#000000"],
+    "peace": ["#F5F5F5", "#E0F7FA"],
+    "epic": [KEY_COLOR_PALETTE["violet"], "#4B0082"],
+    "awe": ["#008080", "#C0C0C0", "#2F4F4F"],
+    "neutral": ["#B0BEC5", "#ECEFF1"],
+    "hope": ["#9ACD32", "#C5E1A5"],
+    "calm": [KEY_COLOR_PALETTE["turquoise"], "#A7FFEB"],
+    "nostalgia": ["#D8BFD8", "#E6E6FA"],
+    "irony": ["#800080", "#C71585"],
+    "conflict": [KEY_COLOR_PALETTE["orange-red"], KEY_COLOR_PALETTE["amber"]],
+    "joy_bright": ["#FFD700", "#FFF59D"],
+    "love_soft": ["#FFC0CB", "#FFE4E1"],
+    "love_deep": ["#C2185B", "#880E4F"],
+    "disappointment": ["#708090", "#A9A9A9"],
+    "melancholy": ["#4B6C9C", "#2F4F4F"],
+    "rage": ["#B22222", "#8B0000"],
+    "rage_extreme": ["#8B0000", "#4A0000"],
+    "aggression": ["#C62828", "#B71C1C"],
+    "anxiety": ["#6A5ACD", "#2F4F4F"],
+    "wonder": ["#7DF9FF", KEY_COLOR_PALETTE["turquoise"]],
+    "gothic_dark": ["#1B1B2F", "#000000"],
+    "dark_poetic": ["#2C1A2E", "#3F2A44"],
+    "dark_romantic": ["#4A192C", "#2C0F1A"],
+    "hiphop_conflict": [KEY_COLOR_PALETTE["orange-red"], KEY_COLOR_PALETTE["green"]],
+    "street_power": ["#8B4513", "#FF8C00"],
+    "dark": ["#111111", "#2F2F2F"],
+    "melancholic": ["#4B5D67", "#243447"],
+    "epic_cluster": [KEY_COLOR_PALETTE["violet"], KEY_COLOR_PALETTE["magenta"]],
+    "hope_cluster": ["#9ACD32", KEY_COLOR_PALETTE["turquoise"]],
+    "neutral_cluster": ["#B0BEC5", "#CFD8DC"],
+}
+
+
+def _normalize_emotion_key(name: str | None) -> str:
+    return (name or "").strip().lower()
+
+
+def get_emotion_colors(emotion: str, *, default: List[str] | None = None) -> List[str]:
+    key = _normalize_emotion_key(emotion)
+    if key in EMOTION_COLOR_MAP:
+        return EMOTION_COLOR_MAP[key]
+    return default or EMOTION_COLOR_MAP["neutral"]
+
+
 @dataclass
 class ColorResolution:
     colors: List[str]
@@ -27,59 +94,26 @@ class ColorEngineAdapter:
     def resolve_color_wave(self, result: Dict[str, Any]) -> ColorResolution:
         tlp = result.get("tlp", {}) or {}
         emo = result.get("emotion", {}) or {}
+        scores: Dict[str, float] = {
+            "truth": float(tlp.get("truth", 0.0)),
+            "love": float(tlp.get("love", 0.0)),
+            "pain": float(tlp.get("pain", 0.0)),
+        }
 
-        # --- Значения по умолчанию ---
-        truth = float(tlp.get("truth", 0.0))
-        love = float(tlp.get("love", 0.0))
-        pain = float(tlp.get("pain", 0.0))
+        for name, value in emo.items():
+            try:
+                scores[_normalize_emotion_key(name)] = float(value)
+            except (TypeError, ValueError):
+                continue
 
-        # Основные эмоциональные коэффициенты
-        hate = float(emo.get("anger", 0.0))
-        sadness = float(emo.get("sadness", 0.0))
-        joy = float(emo.get("joy", 0.0))
-        awe = float(emo.get("awe", 0.0))
-        fear = float(emo.get("fear", 0.0))
+        filtered_scores = {k: v for k, v in scores.items() if v is not None}
+        if not filtered_scores:
+            return ColorResolution(colors=get_emotion_colors("neutral"), source="fallback")
 
-        # --- Цветовые базовые правила (упрощённая версия) ---
-        # Боль / Печаль → синий → тёмный серый
-        if pain > 0.6 or sadness > 0.6:
-            return ColorResolution(
-                colors=["#0A1F44", "#2F4F4F", "#000000"],
-                source="tlp_rules",
-            )
-
-        # Гнев / Ненависть → чёрный → красный → чёрный
-        if hate > 0.7:
-            return ColorResolution(
-                colors=["#000000", "#8B0000", "#000000"],
-                source="emotion_map",
-            )
-
-        # Любовь → красный → розовый → белый
-        if love > 0.6 or joy > 0.6:
-            return ColorResolution(
-                colors=["#FF0000", "#FF69B4", "#FFFFFF"],
-                source="tlp_rules",
-            )
-
-        # Awe / mystic → бирюза → серебро → тень
-        if awe > 0.6:
-            return ColorResolution(
-                colors=["#008080", "#C0C0C0", "#2F4F4F"],
-                source="emotion_map",
-            )
-
-        # Fear → тёмно-фиолетовый → чёрный
-        if fear > 0.6:
-            return ColorResolution(
-                colors=["#2A0038", "#000000"],
-                source="emotion_map",
-            )
-
-        # --- Fallback (если эмоция непонятна) ---
+        dominant = max(filtered_scores, key=filtered_scores.get)
         return ColorResolution(
-            colors=["#222222", "#555555"],
-            source="fallback",
+            colors=get_emotion_colors(dominant),
+            source="emotion_map",
         )
 
 # StudioCore Signature Block (Do Not Remove)

--- a/studiocore/suno_annotations.py
+++ b/studiocore/suno_annotations.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Sequence
 
+from studiocore.color_engine_adapter import EMOTION_COLOR_MAP, get_emotion_colors
+
 
 class EmotionDrivenSunoAdapter:
     """
@@ -26,12 +28,14 @@ class EmotionDrivenSunoAdapter:
         vocal_profile = self._resolve_vocal_profile()
         instrumentation = self._resolve_instrumentation()
         section_annotations = self._build_section_annotations()
+        color_palette = self._resolve_color_palette()
 
         return {
             "style": style,
             "vocal_profile": vocal_profile,
             "instrumentation": instrumentation,
             "section_annotations": section_annotations,
+            "color_palette": color_palette,
         }
 
     # --- Internal helpers ---
@@ -82,6 +86,16 @@ class EmotionDrivenSunoAdapter:
             "narrative": "acoustic guitar, soft percussion",
         }
         return mapping.get(cluster, "hybrid adaptive instrumentation")
+
+    def _resolve_color_palette(self) -> List[str]:
+        cluster = (self.emotion_curve or {}).get("dominant_cluster") or ""
+        cluster_alias = {
+            "despair": "melancholy",
+            "tender": "love_soft",
+            "narrative": "neutral",
+        }
+        target = cluster_alias.get(cluster, cluster) or "neutral"
+        return get_emotion_colors(target, default=EMOTION_COLOR_MAP["neutral"])
 
     def _build_section_annotations(self) -> Dict[str, str]:
         annotations: Dict[str, str] = {}

--- a/studiocore/tone.py
+++ b/studiocore/tone.py
@@ -14,7 +14,12 @@ Unified color–resonance engine for emotional frequency visualization.
 """
 
 import math
-from typing import Dict, Any
+from typing import Any, Dict
+from studiocore.color_engine_adapter import (
+    EMOTION_COLOR_MAP,
+    KEY_COLOR_PALETTE,
+    get_emotion_colors,
+)
 from studiocore.emotion_profile import EmotionVector
 
 
@@ -30,18 +35,18 @@ class ToneSyncEngine:
     )
 
     BASE_COLOR_MAP = {
-        "C": "red",
-        "C#": "orange-red",
-        "D": "golden",
-        "D#": "amber",
-        "E": "yellow",
-        "F": "green",
-        "F#": "turquoise",
-        "G": "blue",
-        "G#": "indigo",
-        "A": "violet",
-        "A#": "magenta",
-        "B": "crimson",
+        "C": KEY_COLOR_PALETTE["red"],
+        "C#": KEY_COLOR_PALETTE["orange-red"],
+        "D": KEY_COLOR_PALETTE["golden"],
+        "D#": KEY_COLOR_PALETTE["amber"],
+        "E": KEY_COLOR_PALETTE["yellow"],
+        "F": KEY_COLOR_PALETTE["green"],
+        "F#": KEY_COLOR_PALETTE["turquoise"],
+        "G": KEY_COLOR_PALETTE["blue"],
+        "G#": KEY_COLOR_PALETTE["indigo"],
+        "A": KEY_COLOR_PALETTE["violet"],
+        "A#": KEY_COLOR_PALETTE["magenta"],
+        "B": KEY_COLOR_PALETTE["crimson"],
     }
 
     RESONANCE_MAP = {
@@ -80,10 +85,14 @@ class ToneSyncEngine:
         if not key or key == "auto":
             return "white"
         base = key.replace(" minor", "").replace(" major", "").replace(" modal", "").strip()
-        base_color = self.BASE_COLOR_MAP.get(base, "white")
+        base_color = self.BASE_COLOR_MAP.get(base, "#FFFFFF")
         # cf-modulated blend toward complementary hue
         if cf > 0.5:
-            blend_target = "violet" if base_color in ("red", "orange-red") else "red"
+            blend_target = (
+                KEY_COLOR_PALETTE["violet"]
+                if base_color in (KEY_COLOR_PALETTE["red"], KEY_COLOR_PALETTE["orange-red"])
+                else KEY_COLOR_PALETTE["red"]
+            )
             return f"{base_color}-{blend_target}"
         return base_color
 
@@ -111,15 +120,9 @@ class ToneSyncEngine:
         resonance = self._resonance_from_key(key, tlp)
         temp = self._derive_mood_temperature(tlp)
 
-        dom = max(emo, key=emo.get)
-        accent = {
-            "joy": "golden glow",
-            "sadness": "blue haze",
-            "anger": "red flash",
-            "fear": "gray mist",
-            "peace": "soft white aura",
-            "epic": "purple light",
-        }.get(dom, "silver reflection")
+        dom = max(emo, key=emo.get) if emo else "neutral"
+        accent_palette = get_emotion_colors(dom, default=EMOTION_COLOR_MAP["neutral"])
+        accent = accent_palette[-1]
 
         harmony_score = round(min(1.0, (tlp.get("love", 0) + tlp.get("truth", 0)) / 2), 3)
         brightness = round(0.5 + cf / 2, 2)


### PR DESCRIPTION
## Summary
- add a canonical emotion→color map and key palette for all mapped emotions
- refactor color resolution, logical engine palettes, and tone accents to draw from the shared mapping
- surface canonical palettes in Suno annotations for downstream consumers

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206ae0d90c83279e07c29e5e905d18)