### PR TITLE
Fix emotion vector export and inline test runner path

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ from dataclasses import asdict
 from typing import Optional
 
 # === 1. Исправление пути импорта ===
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(__file__)
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
@@ -524,13 +525,9 @@ def run_inline_tests():
         buffer.write(f"🚀 Running pytest in {tests_path}\n\n")
 
         process = subprocess.run(
-            [sys.executable, "-m", "pytest", "-q", tests_path],
-            cwd=ROOT,
+            ["pytest", "-q", os.path.join(BASE_DIR, "tests")],
             capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="ignore",
-            timeout=300,
+            text=True
         )
 
         if process.stdout:

--- a/studiocore/tlp_engine.py
+++ b/studiocore/tlp_engine.py
@@ -26,16 +26,24 @@ class TruthLovePainEngine(_TruthLovePainEngine):
         return profile
 
     def export_emotion_vector(self, text: str) -> EmotionVector:
-        """
-        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
-        """
+        profile = self.analyze(text)
+        truth = profile.get("truth", 0.0)
+        love = profile.get("love", 0.0)
+        pain = profile.get("pain", 0.0)
+
+        # Compute Valence and Arousal properly
+        valence = love - pain                      # positivity/negativity
+        arousal = (love + pain + truth) / 3.0      # intensity/energy
+
+        weight = profile.get("conscious_frequency", 0.5)
+
         return EmotionVector(
-            truth=0.0,
-            love=0.0,
-            pain=0.0,
-            valence=0.0,
-            arousal=0.0,
-            weight=1.0,
+            truth=truth,
+            love=love,
+            pain=pain,
+            valence=valence,
+            arousal=arousal,
+            weight=weight,
         )
 
 


### PR DESCRIPTION
## Summary
- compute emotion vector valence and arousal using Truth/Love/Pain analysis
- adjust inline test runner to invoke pytest with correct tests path and base directory
- define BASE_DIR for consistent path handling

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692071de9df8832780f5e6d3800ab38a)