### PR TITLE
Integrate color emotion modulation into ToneSyncEngine

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -586,7 +586,10 @@ class StudioCoreV6:
         try:
             local_tone_mod = []
             for ev in smoothed_vectors:   # список EmotionVector из шага 5
-                mod = self.tone_engine.apply_emotion_modulation(tone_result["key"], ev)
+                mod = self.tone_engine.apply_emotion_modulation(
+                    {"key": tone_result.get("key"), "mode": mode},
+                    ev,
+                )
                 local_tone_mod.append(mod)
             result["_tone_dynamic"] = local_tone_mod
         except Exception:


### PR DESCRIPTION
## Summary
- add color-aware emotion modulation that factors ColorEmotion inputs and arousal-driven key shifts
- provide semitone key shifting utility within ToneSyncEngine
- update tonality pipeline to pass key and mode payloads into the modulation step

## Testing
- pytest
- ruff check (fails: existing lint issues in unrelated files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692078303b108327a1c93f7a252efb97)