### PR TITLE
Expand emotion spectra and lexicon coverage

### DIFF
--- a/studiocore/emotion_engine.py
+++ b/studiocore/emotion_engine.py
@@ -33,28 +33,82 @@ class EmotionEngineV64:
         """Initializes instance-level state to ensure statelessness per-request (Fix #1.1)."""
         # === 24 базовых эмоции (универсальный спектр) ===
         self.EMOTIONS = [
-            "joy", "joy_bright",
-            "love", "love_soft", "love_deep",
-            "sadness", "disappointment", "melancholy",
-            "rage", "rage_extreme", "aggression",
-            "fear", "anxiety",
-            "awe", "wonder",
-            "hope",
-            "gothic_dark", "dark_poetic", "dark_romantic",
-            "hiphop_conflict", "street_power",
-            "peace", "neutral",
+            "joy", "joy_bright", "happiness", "delight",  # Joy Spectrum
+            "calm", "serenity", "trust",  # Calm Spectrum
+            "love", "love_soft", "love_deep", "infinite_love", "healing_love", "maternal_love", "radiant_love", "longing_love", "gentle_love", "unconditional_love",  # Love Spectrum
+            "sadness", "disappointment", "melancholy", "sorrow", "loneliness", "grief", "regret", "guilt", "shame",  # Sadness Spectrum
+            "deep_pain", "phantom_pain", "burning_pain", "soul_pain", "silent_pain", "explosive_pain", "collapsing_pain",  # Pain Spectrum
+            "rage", "rage_extreme", "aggression", "anger", "bitterness", "jealousy", "envy", "betrayal", "resentment",  # Rage Spectrum
+            "fear", "anxiety", "panic", "disgust", "aversion", "confusion", "frustration",  # Fear/Conflict Spectrum
+            "awe", "wonder", "hope", "relief", "admiration",  # Awe/Hope Spectrum
+            "gothic_dark", "dark_poetic", "dark_romantic",  # Dark Spectrum
+            "hiphop_conflict", "street_power",  # Hiphop Spectrum
+            "clear_truth", "cold_truth", "sharp_truth", "brutal_honesty", "revelation", "righteous_truth",  # Truth Spectrum
+            "resolve", "determination",  # Action/Resolve
+            "calm_flow", "warm_pulse", "cold_pulse", "frantic", "trembling", "escalating", "descending", "pressure", "static_tension", "breathless",  # Rhythmic/Structural
+            "peace", "neutral",  # Core States
         ]
 
         # базовые ключевые слова (instance scope)
         self.LEXICON = {
-            "rage": ["убей", "бей", "морг", "кровь", "разорвать", "сломать", "враг"],
+            "rage": ["убей", "бей", "гнев", "ярость", "разрывать", "сломать", "враг", "anger", "fury", "rage"],
             "rage_extreme": ["уничтожь", "смерть", "ненавижу", "истреби"],
             "sadness": ["печаль", "слёзы", "одиноко", "грусть"],
+            "sorrow": ["скорбь", "горечь", "плач", "тоска", "sorrow", "weeping"],
+            "loneliness": ["одиночество", "пустой", "alone", "empty", "lonely"],
+            "grief": ["утрата", "потеря", "невосполним", "loss", "grief"],
+            "regret": ["сожалею", "жалеть", "прошлое", "remorse", "regret"],
+            "guilt": ["виноват", "вина", "ответственность", "guilty", "fault"],
+            "shame": ["позор", "стыд", "унижение", "shame", "disgrace"],
             "disappointment": ["разочарование", "устал", "пустота"],
+            "frustration": ["бессилие", "ярость", "frustration", "powerless"],
+            "deep_pain": ["глубокая боль", "разлом", "бездна", "deep wound", "abyss"],
+            "phantom_pain": ["фантомная боль", "невидимая", "phantom ache"],
+            "burning_pain": ["жжение", "огонь боли", "пламя", "burning ache", "fire of sorrow"],
+            "soul_pain": ["боль души", "сердце разбито", "soul ache", "heart broken"],
+            "silent_pain": ["тихая боль", "немой крик", "silent scream", "mute suffering"],
+            "explosive_pain": ["взрыв", "рвёт", "крик", "explosion", "tearing apart"],
+            "collapsing_pain": ["рухнул", "сломлен", "обрушение", "collapsed", "broken down"],
             "love": ["люблю", "поцелуй", "ласка"],
             "love_soft": ["нежный", "ласковый", "тёплый"],
             "love_deep": ["страсть", "союз", "вечность"],
+            "infinite_love": ["бесконечная любовь", "навсегда", "eternal love", "boundless"],
+            "healing_love": ["исцеление", "заживет", "healing", "mend"],
+            "maternal_love": ["материнский", "забота", "оберег", "motherly", "care", "guardian"],
+            "radiant_love": ["сияющая любовь", "свет", "radiant", "shining"],
+            "longing_love": ["тоска по любви", "ждать", "longing", "yearning"],
+            "unconditional_love": ["безусловная", "без условий", "unconditional", "pure"],
             "joy": ["свет", "улыбка", "радость"],
+            "happiness": ["счастье", "радостно", "веселье", "happy", "cheer"],
+            "delight": ["восторг", "наслаждение", "delight", "pleasure"],
+            "calm": ["спокойствие", "покой", "тишина", "calm", "stillness"],
+            "serenity": ["безмятежность", "гармония", "serenity", "harmony"],
+            "trust": ["доверие", "вера", "уверенность", "trust", "confidence"],
+            "clear_truth": ["ясная правда", "прозрение", "clear sight", "realization"],
+            "cold_truth": ["ледяное прозрение", "холодная правда", "icy clarity", "cold hard fact"],
+            "sharp_truth": ["острая ясность", "болезненная правда", "sharp clarity", "painful truth"],
+            "brutal_honesty": ["жестокая правда", "честность", "brutal honesty"],
+            "revelation": ["озарение", "внезапно", "открытие", "epiphany", "revelation"],
+            "righteous_truth": ["праведная истина", "суд", "righteous", "divine justice"],
+            "fear": ["страх", "тревога", "боязнь", "fear", "anxiety", "dread"],
+            "panic": ["паника", "ужас", "шок", "panic", "terror"],
+            "disgust": ["отвращение", "мерзко", "противно", "disgust", "repulsive"],
+            "bitterness": ["горечь", "желчь", "bitterness", "resentment", "gall"],
+            "jealousy": ["ревность", "зависть", "хочу", "jealousy", "envy"],
+            "betrayal": ["предательство", "измена", "удар в спину", "betrayal", "treachery"],
+            "resentment": ["негодование", "обида", "злой", "indignation", "offense"],
+            "resolve": ["решимость", "цель", "точно", "resolve", "purpose", "certainty"],
+            "determination": ["воля", "твердо", "determination", "will", "firmly"],
+            "calm_flow": ["ровный ритм", "мягкий ход", "steady tempo", "gentle flow"],
+            "warm_pulse": ["тёплая волна", "мягкий бит", "warm wave", "soft pulse"],
+            "cold_pulse": ["холодный ритм", "ледяной бит", "cold beat", "icy pulse"],
+            "frantic": ["безумный", "крайний темп", "быстро", "frantic", "mad speed"],
+            "trembling": ["дрожание", "трясет", "нервно", "trembling", "shaking", "nervous"],
+            "escalating": ["нарастание", "вверх", "рост", "escalating", "rising", "upward"],
+            "descending": ["спад", "вниз", "снижение", "descending", "falling", "decline"],
+            "pressure": ["давление", "тяжесть", "тьма", "pressure", "heavy", "darkness"],
+            "static_tension": ["серый статик", "замер", "ожидание", "gray tension", "motionless"],
+            "breathless": ["задыхаясь", "без воздуха", "breathless", "gasping"],
             "gothic_dark": ["луна", "мрак", "готика", "тьма", "пан", "кровь"],
             "hiphop_conflict": ["улица", "правда", "деньги", "силой"],
             "street_power": ["бетон", "двор", "бит", "флоу"],


### PR DESCRIPTION
## Summary
- expand the emotion spectrum with additional nuanced states and structural cues
- extend the lexicon with richer keywords for newly added emotions to improve detection

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208ecf531c832783e106f47065252b)