### PR TITLE
Add test for strict boundary emotion threshold

### DIFF
--- a/tests/test_section_parser.py
+++ b/tests/test_section_parser.py
@@ -27,6 +27,17 @@ def test_section_parser_detects_annotations():
     assert adjustments["bpm"] >= 120
     assert adjustments["annotations"] == result.annotations
 
+
+def test_section_parser_prefers_strict_boundary_only_for_extreme_rde():
+    parser = SectionParser()
+
+    calm_result = parser.parse("soft glow\nwhisper in the snow")
+    assert calm_result.prefer_strict_boundary is False
+
+    intense_lines = "\n".join(["TOTAL PANIC!!!"] * 18)
+    intense_result = parser.parse(intense_lines)
+    assert intense_result.prefer_strict_boundary is True
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27


### PR DESCRIPTION
## Summary
- add regression test ensuring SectionParser only prefers strict boundaries when extreme RDE emotion is detected

## Testing
- pytest tests/test_section_parser.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b913860483278fcec20c07789ec8)