### PR TITLE
Implement dynamic emotion vector and semantic mapping

### DIFF
--- a/studiocore/emotion.py
+++ b/studiocore/emotion.py
@@ -114,15 +114,23 @@ class TruthLovePainEngine: # <-- v15: Оригинальное имя
 
     def export_emotion_vector(self, text: str) -> EmotionVector:
         """
-        Passive hook. Returns a neutral EmotionVector until dynamic mode is enabled.
+        Calculates dynamic Valence and Arousal based on TLP scores from the base class.
         """
+        profile = self.analyze(text)
+        truth = profile.get("truth", 0.0)
+        love = profile.get("love", 0.0)
+        pain = profile.get("pain", 0.0)
+        weight = profile.get("conscious_frequency", 0.5)
+        valence = love - pain
+        arousal = (love + pain + truth) / 3.0
+
         return EmotionVector(
-            truth=0.0,
-            love=0.0,
-            pain=0.0,
-            valence=0.0,
-            arousal=0.0,
-            weight=1.0,
+            truth=truth,
+            love=love,
+            pain=pain,
+            valence=valence,
+            arousal=arousal,
+            weight=weight,
         )
 
 

--- a/studiocore/monolith_v4_3_1.py
+++ b/studiocore/monolith_v4_3_1.py
@@ -358,25 +358,38 @@ class StudioCore:
         
         num_blocks = len(text_blocks)
         
-        # --- (v6) Улучшенная логика мэппинга секций (ПРИОРИТЕТ Outro) ---
-        # Создаем гибкий паттерн: Intro, Verse, Chorus, Verse, Chorus, Bridge, ...
-        # Это решает проблему некорректного маппинга для длинных текстов.
-        base_map_pattern = ["Intro", "Verse", "Chorus", "Verse", "Chorus", "Bridge"]
-        semantic_map = []
+        # --- (v6) Динамическое построение семантической карты ---
+        # Гарантирует корректный порядок (интро → куплеты/припевы → бридж → аутро)
+        # и стабильное добавление Outro для любых длин текстов.
+        semantic_map: List[str] = []
 
-        for i in range(num_blocks):
-            if i < len(base_map_pattern):
-                semantic_map.append(base_map_pattern[i])
-            else:
-                # Повторяем Verse/Chorus/Verse... для очень длинных песен
-                semantic_map.append(base_map_pattern[i % 2 + 1]) # 1=Verse, 2=Chorus
-
-        # 🎯 ГАРАНТИЯ: Последний блок всегда Outro, как запросил пользователь
         if num_blocks > 0:
-            semantic_map[-1] = "Outro"
-            if num_blocks > 1 and semantic_map[-2] == "Outro":
-                # Если предпоследний был Outro, делаем его Bridge
-                semantic_map[-2] = "Bridge"
+            slots_before_outro = num_blocks - 1
+
+            if slots_before_outro == 0:
+                semantic_map = ["Outro"]
+            else:
+                # Базовый шаблон и повторяющийся цикл куплет/припев
+                base_map_pattern = ["Intro", "Verse", "Chorus", "Verse", "Chorus", "Bridge"]
+                vc_cycle = ["Verse", "Chorus"]
+
+                semantic_map = base_map_pattern[:slots_before_outro]
+
+                # Продолжаем чередование куплет/припев для очень длинных текстов
+                cycle_idx = 0
+                while len(semantic_map) < slots_before_outro:
+                    semantic_map.append(vc_cycle[cycle_idx % len(vc_cycle)])
+                    cycle_idx += 1
+
+                # Особый случай: всего два блока (Verse → Outro)
+                if num_blocks == 2:
+                    semantic_map = ["Verse"]
+
+                # Гарантируем наличие припева, если есть место минимум под два блока до аутро
+                if slots_before_outro >= 2 and "Chorus" not in semantic_map:
+                    semantic_map[-1] = "Chorus"
+
+                semantic_map.append("Outro")
         
         # Находим определения секций
         sec_defs = {s["tag"].lower(): s for s in semantic_sections}


### PR DESCRIPTION
## Summary
- calculate valence, arousal, and weight dynamically when exporting TLP emotion vectors
- rebuild semantic mapping logic to dynamically cover long texts while always ending with an Outro

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c09f614c8327b42225b995cc2d86)