### PR TITLE
Sync tonality payload with emotional modulation

### DIFF
--- a/studiocore/emotion_engine.py
+++ b/studiocore/emotion_engine.py
@@ -181,7 +181,7 @@ class EmotionEngineV64:
         tlp = self.compute_TLP(dominant, vector)
 
         # динамическое обновление веса
-        self.update_weights(vector)
+        # self.update_weights(vector) # COMMENTED OUT: Removing state leak for stateless architecture
 
         return {
             "vector": vector,


### PR DESCRIPTION
## Summary
- disable dynamic weight updates in the emotion engine to prevent state leakage
- record emotionally modulated key/mode and source in the tonality payload and document fusion integration requirements

## Testing
- pytest
- flake8 (fails: existing style violations)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c1f2835c8327a766d0a36b9fb927)