### PR TITLE
Handle legacy failures and streamline vocal pipeline

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -484,6 +484,8 @@ class StudioCoreV6:
         legacy_error_detected = isinstance(legacy_result, dict) and legacy_result.get("error")
         if legacy_error_detected:
             diagnostics["legacy_error"] = {"message": legacy_result.get("error")}
+            # CRITICAL FIX: If legacy core failed, reset the entire result to prevent V6 from using faulty/stale legacy data.
+            legacy_result = {"error": legacy_result["error"]}
 
         # 2. Structural analysis
         structure = {
@@ -571,8 +573,8 @@ class StudioCoreV6:
             "average_intensity": round(sum(vocal_curve) / max(len(vocal_curve), 1), 3) if vocal_curve else 0.5,
         }
         vocal_payload = self._merge_semantic_hints(vocal_payload, semantic_hints.get("vocal", {}))
-        # Fix #2.2: Removed redundant override application (it will be applied once later in _apply_user_overrides_once)
-        vocal_payload = self._apply_vocal_fusion(vocal_payload, override_manager.overrides)
+        # FIX: Removed redundant mid-pipeline vocal fusion/mutation to comply with stateless architecture.
+        # vocal_payload = self._apply_vocal_fusion(vocal_payload, override_manager.overrides)
         vocal_for_instrumentation = dict(vocal_payload)
         diagnostics["vocal"] = dict(vocal_payload)
 

--- a/studiocore/section_parser.py
+++ b/studiocore/section_parser.py
@@ -76,7 +76,8 @@ class SectionParser:
             for entry in metadata
         ]
         # Force-update internal engine state (required for consistency with section_metadata calls)
-        self._text_engine._section_metadata = metadata
+        # FIX: Direct access to private member is removed. We trust auto_section_split to initialize it.
+        # self._text_engine._section_metadata = metadata
 
         # Final safety check on metadata length to prevent downstream misalignment (Fix #1.2)
         if len(metadata) < len(resolved_sections):


### PR DESCRIPTION
## Summary
- reset legacy analysis results when the legacy core reports an error to prevent stale data and improve diagnostics
- remove mid-pipeline vocal fusion to keep vocal payload stateless before downstream overrides
- stop directly mutating section parser private metadata in favor of auto_section_split initialization

## Testing
- pytest
- python -m compileall studiocore


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c3474a70832792a8f3841c8fd522)