### PR TITLE
Fix stateless emotion scoring and correct translation fallback flag

### DIFF
--- a/studiocore/emotion_engine.py
+++ b/studiocore/emotion_engine.py
@@ -129,7 +129,8 @@ class EmotionEngineV64:
         for emotion, words in self.LEXICON.items():
             for w in words:
                 if w in lower_text:
-                    vector[emotion] += 1.0 * self.WEIGHTS.get(emotion, 1.0)  # Use instance WEIGHTS
+                    # FIX: Enforcing statelessness by removing reliance on self.WEIGHTS
+                    vector[emotion] += 1.0
 
         # нормализация
         total = sum(vector.values()) or 1

--- a/studiocore/text_utils.py
+++ b/studiocore/text_utils.py
@@ -258,10 +258,11 @@ def translate_text_for_analysis(text: str, language: str) -> Tuple[str, bool]:
 
     # 3. Концептуальный Fallback: Имитация успешного перевода (для выполнения контракта)
     log.info(
-        "Simulating translation from '%s' to 'en' (multilingual enablement) to fulfill core analysis contract.",
+        "Translation not available for '%s'. Proceeding with original text.",
         language,
     )
-    return text, True  # Возвращаем исходный текст, но с флагом True
+    # FIX: Was returning (text, True) which incorrectly signaled a successful translation.
+    return text, False
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -21,7 +21,7 @@ def test_translate_text_for_analysis_simulates_for_unsupported(caplog):
         translated, was_translated = translate_text_for_analysis("texto", "es")
 
     assert translated == "texto"
-    assert was_translated is True
+    assert was_translated is False
     assert any(
-        "Simulating translation" in record.message for record in caplog.records
+        "Translation not available" in record.message for record in caplog.records
     )


### PR DESCRIPTION
## Summary
- remove reliance on mutable weights when tallying emotion lexicon hits to keep analysis stateless
- adjust translation fallback logging and flag to reflect absence of translation instead of simulating success
- update tests to match the new translation fallback behavior

## Testing
- pytest
- python -m compileall studiocore tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c825d9e8832795c7674d7952c39d)