### PR TITLE
Remove stateful emotion weights

### DIFF
--- a/studiocore/emotion_engine.py
+++ b/studiocore/emotion_engine.py
@@ -115,7 +115,7 @@ class EmotionEngineV64:
         }
 
         # индивидуальные веса (динамически обучаются, instance scope)
-        self.WEIGHTS = {emotion: 1.0 for emotion in self.EMOTIONS}
+        # FIX: Removed self.WEIGHTS initialization to enforce statelessness.
 
     def analyze_emotion(self, text: str) -> Dict[str, float]:
         """
@@ -160,14 +160,19 @@ class EmotionEngineV64:
                           vector.get("disappointment", 0), 3),
         }
 
-    def update_weights(self, vector: Dict[str, float]) -> None:
+    def update_weights(self, vector: Dict[str, float]) -> Dict[str, float]:
         """
         Самообучение на основе входного текста.
         Усиливаем эмоции, которые часто встречаются.
+
+        Возвращает новый словарь весов без сохранения состояния экземпляра.
         """
+        weights = {emotion: 1.0 for emotion in self.EMOTIONS}
         for emotion, score in vector.items():
             # логарифмическое усиление (без взрывов)
-            self.WEIGHTS[emotion] = round(self.WEIGHTS.get(emotion, 1.0) + math.log1p(score), 5)  # Use instance WEIGHTS
+            weights[emotion] = round(weights.get(emotion, 1.0) + math.log1p(score), 5)
+
+        return weights
 
     def process(self, text: str) -> Dict[str, object]:
         """


### PR DESCRIPTION
## Summary
- remove the emotion engine's persistent weight initialization to keep request handling stateless
- update the weight calculation helper to return a fresh dictionary instead of mutating instance state

## Testing
- python -m pytest
- python -m compileall studiocore

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920cc717bc08327931cf9ca96bfe822)