### PR TITLE
Fix raw block parsing and chorus BPM for final tag

### DIFF
--- a/studiocore/monolith_v4_3_1.py
+++ b/studiocore/monolith_v4_3_1.py
@@ -398,8 +398,10 @@ class StudioCore:
         sec_defs.setdefault("verse 2", sec_defs["verse"])
         # --- Конец логики мэппинга ---
 
-        final_bpm = semantic_sections[0].get("bpm", 120) # (BPM припева)
-        final_key = semantic_sections[0].get("key", "auto")
+        # FIX: Use the calculated Chorus BPM as the final tag BPM for consistency (semantic_sections[3] = Chorus)
+        chorus_section = semantic_sections[3] if len(semantic_sections) > 3 else semantic_sections[0]
+        final_bpm = chorus_section.get("bpm", 120) # (BPM припева)
+        final_key = chorus_section.get("key", "auto")
         final_vocal_form = "solo_auto" # Будет перезаписан
 
         # FIX: The original logic failed to correctly map and apply the section tags due to Monolith limitations.

--- a/studiocore/text_utils.py
+++ b/studiocore/text_utils.py
@@ -204,20 +204,21 @@ def extract_phrases_from_section(section_text: str) -> List[str]:
 # Эта функция была в monolith_v4_3_1.py, но monolith v6 вызывает ее отсюда.
 def extract_raw_blocks(text: str) -> List[str]:
     """
-    Разделяет текст на блоки по пустой строке, 
+    Разделяет текст на блоки по пустой строке,
     ИГНОРИРУЯ теги [Intro], (шепотом) и т.д.
     """
-    # Заменяем [Tag] и (hint) на заглушки, чтобы re.split их не видел
-    text_no_tags = re.sub(r"^\s*\[[^\]]+\]\s*$", "TAG_PLACEHOLDER", text, flags=re.MULTILINE)
-    text_no_tags = re.sub(r"^\s*\([^\)]+\)\s*$", "HINT_PLACEHOLDER", text_no_tags, flags=re.MULTILINE)
-    
+    # FIX: Structural integrity. We remove hints, but ensure section tags are preserved as block content.
+
+    # Удаляем ТОЛЬКО hints/commentary in parenthesis () as they are noise.
+    text_no_hints = re.sub(r"\s*\([^\)]+\)", "", text)
+
     # Разделяем по пустой строке
-    blocks = re.split(r"\n\s*\n", text_no_tags.strip())
-    
-    # Очищаем блоки от заглушек (на всякий случай) и пустых строк
+    blocks = re.split(r"\n\s*\n", text_no_hints.strip())
+
+    # Очищаем блоки от пустых строк и пробелов
     cleaned_blocks = []
     for block in blocks:
-        clean_block = block.replace("TAG_PLACEHOLDER", "").replace("HINT_PLACEHOLDER", "").strip()
+        clean_block = block.strip()
         if clean_block:
             cleaned_blocks.append(clean_block)
 


### PR DESCRIPTION
## Summary
- update raw block extraction to strip parenthetical hints while preserving section labels and clean block boundaries
- use the chorus semantic section to drive final BPM/key annotations for consistent end tags

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d4ea5abc8327bf235d3798ed0fe7)