### PR TITLE
Add full diagnostics workflow and script

### DIFF
--- a/.github/workflows/full-diagnostics.yml
+++ b/.github/workflows/full-diagnostics.yml
@@ -1,0 +1,26 @@
+name: Full Diagnostics
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  diagnostics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run full diagnostics
+        run: bash $GITHUB_WORKSPACE/run_full_diag.sh

--- a/run_full_diag.sh
+++ b/run_full_diag.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve project root
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$ROOT_DIR"
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run the diagnostics script using an absolute workspace path
- provide a run_full_diag.sh helper that installs dependencies and executes pytest

## Testing
- pytest *(fails: existing expectations in semantic mapping and translation utilities)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e55483cc83278ca63f060362b1ac)