### PR TITLE
Add pre-merge guard workflow

### DIFF
--- a/.github/workflows/pre_merge_guard.yml
+++ b/.github/workflows/pre_merge_guard.yml
@@ -1,0 +1,28 @@
+name: Pre-Merge Guard
+
+on:
+  pull_request:
+
+jobs:
+  run-full-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+
+      - name: Run full diagnostics
+        run: bash ${{ github.workspace }}/run_full_diag.sh
+
+      - name: Run pytest
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add a pre-merge GitHub Actions workflow to run diagnostics and pytest on pull requests
- set up Python 3.12 and install dependencies before running checks

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ea59c3ec8327982fbf714f89cba9)