### PR TITLE
Add nightly diagnostics patrol workflow

### DIFF
--- a/.github/workflows/nightly_diagnostics.yml
+++ b/.github/workflows/nightly_diagnostics.yml
@@ -1,0 +1,43 @@
+name: Nightly Diagnostics Patrol
+
+on:
+  schedule:
+    - cron: "0 2 * * *"   # запуск каждый день в 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  nightly-diagnostics:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+
+      - name: Run full diagnostics
+        run: bash ${{ github.workspace }}/run_full_diag.sh
+
+      - name: Run pytest
+        run: pytest -q
+
+      - name: Append nightly status to lgp.txt
+        run: |
+          echo "\n=== Nightly patrol — $(date -u) UTC ===" >> main/lgp.txt
+          echo "Diagnostics completed successfully." >> main/lgp.txt
+
+      - name: Create issue if diagnostics fail
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Nightly Diagnostics FAILED — ${{ github.run_id }}"
+          content-filepath: main/lgp.txt
+          labels: nightly, diagnostics,


### PR DESCRIPTION
## Summary
- add a nightly diagnostics GitHub Actions workflow to run full diagnostics and pytest
- append nightly status entries to lgp.txt and create an issue automatically on failures

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920eb9abcf88327a3c9b672adabe64b)