### PR TITLE
Fix auto_trigger syntax and execution path

### DIFF
--- a/main/auto_trigger.py
+++ b/main/auto_trigger.py
@@ -1,12 +1,17 @@
-diff --git a/main/auto_trigger.py b/main/auto_trigger.py
-new file mode 100644
-index 0000000000000000000000000000000000000000..e384f52f87aa2937a13bc3781bba0bde7a7b4dd4
---- /dev/null
-+++ b/main/auto_trigger.py
-@@ -0,0 +1,6 @@
-+# Auto-trigger for full diagnostics — created 2025-11-21T22:04:15.340308 UTC
-+import subprocess
-+import sys
-+print(">>> AutoTrigger: launching full diagnostics...")
-+subprocess.run(["bash", "../run_full_diag.sh"], check=True)
-+print(">>> AutoTrigger complete")
+# Auto-trigger for full diagnostics
+# Runs run_full_diag.sh safely from GitHub Actions and local CI.
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    print(">>> AutoTrigger: launching full diagnostics...")
+    script = Path(__file__).resolve().parent.parent / "run_full_diag.sh"
+    subprocess.run(["bash", str(script)], check=True)
+    print(">>> AutoTrigger complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rewrite auto_trigger.py to be a proper executable module
- resolve script path relative to repository root and run through bash
- add helpful logging around diagnostics execution

## Testing
- python -m compileall main/auto_trigger.py
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed231c0483278491a910a867ebb1)