### PR TITLE
Add exit status to workflow diagnostics and tests

### DIFF
--- a/main/full_system_diagnostics.py
+++ b/main/full_system_diagnostics.py
@@ -7,70 +7,85 @@ checks performed in CI so issues can be caught locally.
 """
 
 from pathlib import Path
+
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 WF_DIR = ROOT / ".github" / "workflows"
 
-errors: list[str] = []
-info: list[str] = []
 
+def _collect_workflow_diagnostics() -> tuple[list[str], list[str]]:
+    """Gather workflow validation info and error messages."""
 
-def add(msg: str) -> None:
-    """Record an error message."""
+    errors: list[str] = []
+    info: list[str] = []
 
-    errors.append(msg)
+    def add(msg: str) -> None:
+        """Record an error message."""
 
+        errors.append(msg)
 
-# 1. Validate YAML syntax for all workflows
-for wf in WF_DIR.glob("*.yml"):
-    try:
+    # 1. Validate YAML syntax for all workflows
+    for wf in WF_DIR.glob("*.yml"):
+        try:
+            txt = wf.read_text(encoding="utf-8")
+            yaml.safe_load(txt)
+            info.append(f"[OK] YAML syntax valid → {wf.name}")
+        except Exception as exc:  # pragma: no cover - diagnostic output
+            add(f"[YAML ERROR] {wf.name}: {exc}")
+
+    # 2. Verify referenced files in run steps exist
+    for wf in WF_DIR.glob("*.yml"):
         txt = wf.read_text(encoding="utf-8")
-        yaml.safe_load(txt)
-        info.append(f"[OK] YAML syntax valid → {wf.name}")
-    except Exception as exc:  # pragma: no cover - diagnostic output
-        add(f"[YAML ERROR] {wf.name}: {exc}")
+        for line in txt.splitlines():
+            line = line.strip()
+            if line.startswith("run:"):
+                cmd = line.replace("run:", "").strip()
 
-# 2. Verify referenced files in run steps exist
-for wf in WF_DIR.glob("*.yml"):
-    txt = wf.read_text(encoding="utf-8")
-    for line in txt.splitlines():
-        line = line.strip()
-        if line.startswith("run:"):
-            cmd = line.replace("run:", "").strip()
+                if "run_full_diag.sh" in cmd:
+                    if not (ROOT / "run_full_diag.sh").exists():
+                        add(f"[MISSING FILE] run_full_diag.sh not found (workflow: {wf.name})")
 
-            if "run_full_diag.sh" in cmd:
-                if not (ROOT / "run_full_diag.sh").exists():
-                    add(f"[MISSING FILE] run_full_diag.sh not found (workflow: {wf.name})")
+                if "auto_log_cleaner.py" in cmd:
+                    if not (ROOT / "main" / "auto_log_cleaner.py").exists():
+                        add(f"[MISSING FILE] auto_log_cleaner.py not found (workflow: {wf.name})")
 
-            if "auto_log_cleaner.py" in cmd:
-                if not (ROOT / "main" / "auto_log_cleaner.py").exists():
-                    add(f"[MISSING FILE] auto_log_cleaner.py not found (workflow: {wf.name})")
+                if "full_system_diagnostics.py" in cmd:
+                    if not (ROOT / "main" / "full_system_diagnostics.py").exists():
+                        add(f"[MISSING FILE] full_system_diagnostics.py not found (workflow: {wf.name})")
 
-            if "full_system_diagnostics.py" in cmd:
-                if not (ROOT / "main" / "full_system_diagnostics.py").exists():
-                    add(f"[MISSING FILE] full_system_diagnostics.py not found (workflow: {wf.name})")
+    # 3. Ensure run_full_diag.sh is executable
+    run_full_diag = ROOT / "run_full_diag.sh"
+    if run_full_diag.exists():
+        mode = run_full_diag.stat().st_mode
+        if not (mode & 0o100):
+            add("[PERMISSION ERROR] run_full_diag.sh is not executable (chmod +x missing)")
+    else:
+        add("[FILE NOT FOUND] run_full_diag.sh missing")
 
-# 3. Ensure run_full_diag.sh is executable
-run_full_diag = ROOT / "run_full_diag.sh"
-if run_full_diag.exists():
-    mode = run_full_diag.stat().st_mode
-    if not (mode & 0o100):
-        add("[PERMISSION ERROR] run_full_diag.sh is not executable (chmod +x missing)")
-else:
-    add("[FILE NOT FOUND] run_full_diag.sh missing")
+    # 4. Confirm required main/*.py files exist
+    main_dir = ROOT / "main"
+    for filename in ["full_system_diagnostics.py", "auto_trigger.py", "auto_log_cleaner.py"]:
+        if not (main_dir / filename).exists():
+            add(f"[MISSING FILE] main/{filename} does not exist")
 
-# 4. Confirm required main/*.py files exist
-MAIN = ROOT / "main"
-for filename in ["full_system_diagnostics.py", "auto_trigger.py", "auto_log_cleaner.py"]:
-    if not (MAIN / filename).exists():
-        add(f"[MISSING FILE] main/{filename} does not exist")
+    return errors, info
 
-print("============== WORKFLOW CHECK ==============")
-print("\n".join(info))
-print("-------------------------------------------")
-if errors:
-    print("❌ ERRORS FOUND:")
-    print("\n".join(errors))
-else:
+
+def main() -> int:
+    errors, info = _collect_workflow_diagnostics()
+
+    print("============== WORKFLOW CHECK ==============")
+    print("\n".join(info))
+    print("-------------------------------------------")
+    if errors:
+        print("❌ ERRORS FOUND:")
+        print("\n".join(errors))
+        return 1
+
     print("✔ No workflow errors detected")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_full_system_diagnostics.py
+++ b/tests/test_full_system_diagnostics.py
@@ -1,0 +1,57 @@
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e
+
+from pathlib import Path
+import subprocess
+import textwrap
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_full_system_diagnostics_passes_for_valid_workflows():
+    result = subprocess.run(
+        ["python3", "main/full_system_diagnostics.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "✔ No workflow errors detected" in result.stdout
+
+
+def test_full_system_diagnostics_fails_on_invalid_workflow():
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    bad_workflow = workflows_dir / "invalid.yml"
+    bad_workflow.write_text(textwrap.dedent("""
+        name: invalid workflow
+        on: [push]
+        jobs:
+          bad:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo "unterminated
+              - run: [missing-closing-bracket
+    """), encoding="utf-8")
+
+    try:
+        result = subprocess.run(
+            ["python3", "main/full_system_diagnostics.py"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        bad_workflow.unlink(missing_ok=True)
+
+    assert result.returncode == 1
+    assert "[YAML ERROR] invalid.yml" in result.stdout
+
+
+# StudioCore Signature Block (Do Not Remove)
+# Author: Сергей Бауэр (@Sbauermaner)
+# Fingerprint: StudioCore-FP-2025-SB-9fd72e27
+# Hash: 22ae-df91-bc11-6c7e


### PR DESCRIPTION
## Summary
- wrap workflow diagnostics in a callable entry point and return exit codes
- surface non-zero status when workflow validation errors occur
- add coverage to verify success and failure paths for the diagnostics script

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920f2379fc48327b90fdbee9c7bc3ed)