### PR TITLE
Enforce stateless StudioCoreV6 input handling

### DIFF
--- a/studiocore/config.py
+++ b/studiocore/config.py
@@ -15,6 +15,7 @@ StudioCore Configuration Loader
 
 import os
 import json
+from dataclasses import dataclass
 
 # Canonical StudioCore version. Legacy labels kept for backward compatibility only.
 STUDIOCORE_VERSION = "v6.4-maxi"
@@ -30,6 +31,7 @@ VERSION_LIMITS = {
 
 DEFAULT_CONFIG = {
     "suno_version": "v5",
+    "MAX_INPUT_LENGTH": 16000,
     "safety": {
         "max_peak_db": -1.0,        # ограничение на пиковый уровень
         "max_rms_db": -14.0,        # средний RMS-уровень
@@ -50,6 +52,12 @@ DEFAULT_CONFIG = {
         "enable_auto_repair": True
     }
 }
+
+
+@dataclass
+class StudioCoreConfig:
+    # Soft input protection
+    MAX_INPUT_LENGTH: int = 16000
 
 
 def load_config(path: str = "studio_config.json") -> dict:

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -220,12 +220,31 @@ class StudioCoreV6:
         from .monolith_v4_3_1 import StudioCore as LegacyCore  # pylint: disable=import-outside-toplevel
 
         self._legacy_core_cls = LegacyCore
-        self._last_backend_payload: Dict[str, Any] = {}
 
     def analyze(self, text: str, **kwargs: Any) -> Dict[str, Any]:
         incoming_text = text or ""
-        self._last_backend_payload = {}
         self.text_engine.reset()
+
+        # === MAX_INPUT_LENGTH ENFORCEMENT ===
+        max_len = int(
+            getattr(DEFAULT_CONFIG, "MAX_INPUT_LENGTH", 0)
+            or (DEFAULT_CONFIG.get("MAX_INPUT_LENGTH") if isinstance(DEFAULT_CONFIG, dict) else 0)
+            or 0
+        )
+        if max_len > 0 and len(incoming_text) > max_len:
+            truncated_text = incoming_text[:max_len]
+            diagnostics = {
+                "engine": "StudioCoreV6",
+                "input_truncated": True,
+                "max_input_length": max_len,
+                "original_length": len(incoming_text),
+            }
+            incoming_text = truncated_text
+        else:
+            diagnostics = {
+                "engine": "StudioCoreV6",
+                "input_truncated": False,
+            }
         params = self._merge_user_params(dict(kwargs))
         overrides: UserOverrides = params.get("user_overrides")
         override_manager = UserOverrideManager(overrides)
@@ -311,6 +330,8 @@ class StudioCoreV6:
             context=self.section_parser.latest_metadata,
         )
         backend_payload.setdefault("fanf", fanf_output)
+        diagnostics_block = backend_payload.get("diagnostics") if isinstance(backend_payload.get("diagnostics"), dict) else {}
+        backend_payload["diagnostics"] = {**diagnostics_block, **diagnostics}
         return self._finalize_result(backend_payload)
 
     def _merge_user_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1548,7 +1569,6 @@ class StudioCoreV6:
             "structure_alignment": bool(structure.get("sections")),
             "zero_pulse_alignment": not bool(zero_pulse_payload.get("has_zero_pulse")),
         }
-        self._last_backend_payload = dict(result)
 
         # === SAFE DIAGNOSTICS FALLBACK ===
         emotion_matrix = result.get("emotion_matrix", {})
@@ -1620,12 +1640,22 @@ class StudioCoreV6:
             "fanf_context": context,
         }
 
-    def annotate_ui(self) -> str | None:
-        fanf_block = self._last_backend_payload.get("fanf", {}) if isinstance(self._last_backend_payload, dict) else {}
+    def annotate_ui(self, payload: Dict[str, Any] | None = None) -> str | None:
+        """Functional, stateless FANF → UI."""
+        if not isinstance(payload, dict):
+            return None
+        fanf_block = payload.get("fanf") or {}
+        if not isinstance(fanf_block, dict):
+            return None
         return fanf_block.get("annotated_text_ui")
 
-    def annotate_suno(self) -> str | None:
-        fanf_block = self._last_backend_payload.get("fanf", {}) if isinstance(self._last_backend_payload, dict) else {}
+    def annotate_suno(self, payload: Dict[str, Any] | None = None) -> str | None:
+        """Functional, stateless FANF → Suno."""
+        if not isinstance(payload, dict):
+            return None
+        fanf_block = payload.get("fanf") or {}
+        if not isinstance(fanf_block, dict):
+            return None
         return fanf_block.get("annotated_text_suno")
 
     def _apply_vocal_fusion(self, vocal_payload: Dict[str, Any], overrides: UserOverrides | None) -> Dict[str, Any]:

--- a/tests/test_stateless_core.py
+++ b/tests/test_stateless_core.py
@@ -1,0 +1,11 @@
+from studiocore.core_v6 import StudioCoreV6
+
+
+def test_stateless_analysis_leak():
+    core = StudioCoreV6()
+
+    p1 = core.analyze("first text")
+    p2 = core.analyze("second text")
+
+    assert p1 != p2
+    assert core.annotate_ui(p1) != core.annotate_ui(p2)


### PR DESCRIPTION
## Summary
- enforce MAX_INPUT_LENGTH handling in StudioCoreV6 while keeping analysis diagnostics stateless
- remove cached backend payload usage and make annotation helpers accept explicit payloads
- add a default MAX_INPUT_LENGTH config entry and regression test to verify stateless analysis

## Testing
- pytest tests/test_stateless_core.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c1f0d6348327b2d33b8d6f1bcd54)