### PR TITLE
Add v2 heuristic engines and improve integrations

### DIFF
--- a/studiocore/bpm_engine.py
+++ b/studiocore/bpm_engine.py
@@ -17,6 +17,43 @@ from .logical_engines import BPMEngine as _CoreBPMEngine
 class BPMEngine(_CoreBPMEngine):
     """Expose a concise helper API for rhythm-aware tooling."""
 
+    def compute_bpm_v2(self, lines: Sequence[str]) -> int:
+        """Грубый, но flow-aware расчёт BPM: длина строк + слоги + плотность."""
+        text_lines = [ln.strip() for ln in lines if ln.strip()]
+        if not text_lines:
+            return 90
+
+        def syllable_count(s: str) -> int:
+            vowels = "aeiouyауоыиэяюёе"
+            return max(1, sum(1 for ch in s.lower() if ch in vowels))
+
+        total_syllables = 0
+        total_words = 0
+        for ln in text_lines:
+            words = ln.split()
+            total_words += len(words)
+            total_syllables += syllable_count(ln)
+
+        avg_syllables_per_word = total_syllables / max(total_words, 1)
+        avg_len = sum(len(ln) for ln in text_lines) / max(len(text_lines), 1)
+
+        # Базовый BPM
+        bpm = 80
+
+        # Ускоряем, если текст плотный и длинный
+        if avg_syllables_per_word > 2.8:
+            bpm += 10
+        if avg_syllables_per_word > 3.3:
+            bpm += 15
+
+        if avg_len > 60:
+            bpm += 10
+        elif avg_len < 30:
+            bpm -= 5
+
+        bpm = max(40, min(200, int(bpm)))
+        return bpm
+
     def describe(self, text: str, *, sections: Sequence[str] | None = None) -> Dict[str, Any]:
         resolved_sections = list(sections) if sections else [text]
         joined_text = "\n\n".join(resolved_sections)

--- a/studiocore/config.py
+++ b/studiocore/config.py
@@ -43,6 +43,25 @@ DEFAULT_CONFIG = ConfigAccessor(
     {
         "suno_version": "v5",
         "MAX_INPUT_LENGTH": 16000,
+        "EMOTION_MIN_SIGNAL": 0.05,
+        "EMOTION_HIGH_SIGNAL": 0.65,
+        "TLP_CLAMP_MIN": 0.0,
+        "TLP_CLAMP_MAX": 1.0,
+        "AGGRESSION_KEYWORDS": (
+            "убей",
+            "убивать",
+            "расстрелять",
+            "зарежь",
+            "уничтожь",
+            "kill",
+            "murder",
+            "slaughter",
+            "execute",
+        ),
+        "FALLBACK_NEUTRAL_TEXT": "Конфликт описывается в тексте, но мы выбираем говорить о примирении и выходе из насилия.",
+        "FALLBACK_NEUTRAL_STYLE": "cinematic narrative",
+        "ERROR_INVALID_INPUT_TYPE": "invalid_input_type",
+        "ERROR_EMPTY_INPUT": "empty_input",
         "safety": {
             "max_peak_db": -1.0,        # ограничение на пиковый уровень
             "max_rms_db": -14.0,        # средний RMS-уровень
@@ -78,6 +97,32 @@ DEFAULT_CONFIG = ConfigAccessor(
 class StudioCoreConfig:
     # Soft input protection
     MAX_INPUT_LENGTH: int = 16000
+    # Emotion & TLP thresholds
+    EMOTION_MIN_SIGNAL: float = 0.05
+    EMOTION_HIGH_SIGNAL: float = 0.65
+    TLP_CLAMP_MIN: float = 0.0
+    TLP_CLAMP_MAX: float = 1.0
+
+    # Aggression / violence lexicon (for filters, not for prompts)
+    AGGRESSION_KEYWORDS: tuple[str, ...] = (
+        "убей",
+        "убивать",
+        "расстрелять",
+        "зарежь",
+        "уничтожь",
+        "kill",
+        "murder",
+        "slaughter",
+        "execute",
+    )
+
+    # Neutral fallback phrases (instead of aggressive ones)
+    FALLBACK_NEUTRAL_TEXT: str = "Конфликт описывается в тексте, но мы выбираем говорить о примирении и выходе из насилия."
+    FALLBACK_NEUTRAL_STYLE: str = "cinematic narrative"
+
+    # Error messages
+    ERROR_INVALID_INPUT_TYPE: str = "invalid_input_type"
+    ERROR_EMPTY_INPUT: str = "empty_input"
     # Fallback messages, avoids hardcoding inside core
     FALLBACK_STYLE: str = "cinematic narrative"
     FALLBACK_KEY: str = "C minor"

--- a/studiocore/rde_engine.py
+++ b/studiocore/rde_engine.py
@@ -86,7 +86,52 @@ class RhythmDynamicsEmotionEngine:
         return round(min(1.0, unique / total), 4)
 
 
-__all__ = ["RDESnapshot", "RhythmDynamicsEmotionEngine"]
+class ResonanceDynamicsEngine:
+    # keep existing code but add:
+
+    def calc_resonance(self, text: str) -> float:
+        """Псевдо-резонанс: повторяемость ключевых слов и ритмических паттернов."""
+        low = text.lower()
+        repeats = 0
+        tokens = low.split()
+        seen: Dict[str, int] = {}
+        for t in tokens:
+            seen[t] = seen.get(t, 0) + 1
+        for cnt in seen.values():
+            if cnt > 1:
+                repeats += cnt - 1
+
+        resonance = min(1.0, repeats / max(len(tokens), 1))
+        return round(resonance, 4)
+
+    def calc_fracture(self, text: str) -> float:
+        """Грубая фрактурность: скачки длины строк и пунктуации."""
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        if len(lines) < 2:
+            return 0.1
+
+        lens = [len(ln) for ln in lines]
+        avg = sum(lens) / len(lens)
+        variance = sum((l - avg) ** 2 for l in lens) / len(lens)
+        fracture = min(1.0, variance / max(avg**2, 1.0))
+        return round(fracture, 4)
+
+    def calc_entropy(self, text: str) -> float:
+        """Символная энтропия (очень упрощённая)."""
+        low = text.lower()
+        length = max(len(low), 1)
+        freq: Dict[str, int] = {}
+        for ch in low:
+            freq[ch] = freq.get(ch, 0) + 1
+        entropy = 0.0
+        for cnt in freq.values():
+            p = cnt / length
+            entropy -= p * (0 if p <= 0 else (p).bit_length())  # дешёвый суррогат логарифма
+        entropy = min(1.0, max(0.0, entropy / 10.0))
+        return round(entropy, 4)
+
+
+__all__ = ["RDESnapshot", "RhythmDynamicsEmotionEngine", "ResonanceDynamicsEngine"]
 
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)


### PR DESCRIPTION
## Summary
- extend configuration with emotion/TLP thresholds, neutral fallbacks, and error constants
- add heuristic v2 emotion, TLP, BPM, and RDE calculations and integrate them into core_v6 diagnostics
- bolster Fusion/Suno integration with logging-backed error handling and stateless returns

## Testing
- python -m compileall studiocore


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c7d3f53083279c2fe5873fe844ce)