### PR TITLE
Move keyword and genre mappings to configuration constants

### DIFF
--- a/studiocore/config.py
+++ b/studiocore/config.py
@@ -164,6 +164,23 @@ def load_config(path: str = "studio_config.json") -> dict:
 
     return data
 
+# === Imported from core_v6 (MAXI FIX v7 — Part 3) ===
+KEYWORD_MAP = [
+    ("melancholy_dark", ["готик", "darkwave", "мрак", "тьма", "темн"]),
+    ("rage_extreme", ["убей", "уничтож", "ненавиж", "смерт", "rage"]),
+    ("love_soft", ["люб", "поцел", "неж", "ласк", "тепл"]),
+    ("joy_bright", ["солн", "чудо", "радост", "улыб", "свет"]),
+    ("confidence", ["бит", "улиц", "флоу", "правда", "силой", "hiphop", "рэп"]),
+]
+
+FORCED_GENRES = {
+    "melancholy_dark": "gothic adaptive darkwave",
+    "rage_extreme": "ideological extreme adaptive rage",
+    "love_soft": "lyrical love adaptive classic",
+    "joy_bright": "pop adaptive light",
+    "confidence": "hiphop adaptive",
+}
+
 # StudioCore Signature Block (Do Not Remove)
 # Author: Сергей Бауэр (@Sbauermaner)
 # Fingerprint: StudioCore-FP-2025-SB-9fd72e27

--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -68,7 +68,7 @@ from .user_override_manager import UserOverrideManager, UserOverrides
 from studiocore.emotion_map import EmotionMapEngine
 from studiocore.emotion_curve import build_global_emotion_curve
 from studiocore.frequency import RNSSafety, UniversalFrequencyEngine
-from studiocore.config import DEFAULT_CONFIG
+from studiocore.config import DEFAULT_CONFIG, FORCED_GENRES, KEYWORD_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +398,6 @@ class StudioCoreV6:
         Stateless constructor: only load static config.
         No engines or parsers must be created here.
         """
-        from .config import DEFAULT_CONFIG
 
         self.config = DEFAULT_CONFIG
 
@@ -1522,15 +1521,8 @@ class StudioCoreV6:
             or self.style_engine.genre_selection(emotion_profile, tlp_profile)
         )
         emotion_label = (tlp_profile.get("dominant_name") or tlp_profile.get("emotion") or "").lower()
-        forced_genres = {
-            "melancholy_dark": "gothic adaptive darkwave",
-            "rage_extreme": "ideological extreme adaptive rage",
-            "love_soft": "lyrical love adaptive classic",
-            "joy_bright": "pop adaptive light",
-            "confidence": "hiphop adaptive",
-        }
-        if not style_commands.get("genre") and emotion_label in forced_genres:
-            style_genre = forced_genres[emotion_label]
+        if not style_commands.get("genre") and emotion_label in FORCED_GENRES:
+            style_genre = FORCED_GENRES[emotion_label]
         style_mood = (
             style_commands.get("mood")
             or semantic_hints.get("style", {}).get("mood")
@@ -2286,14 +2278,7 @@ class StudioCoreV6:
 
     def _resolve_dominant_emotion(self, text: str, emotion_profile: Dict[str, float]) -> str:
         corpus = text.lower()
-        keyword_map = [
-            ("melancholy_dark", ["готик", "darkwave", "мрак", "тьма", "темн"]),
-            ("rage_extreme", ["убей", "уничтож", "ненавиж", "смерт", "rage"]),
-            ("love_soft", ["люб", "поцел", "неж", "ласк", "тепл"]),
-            ("joy_bright", ["солн", "чудо", "радост", "улыб", "свет"]),
-            ("confidence", ["бит", "улиц", "флоу", "правда", "силой", "hiphop", "рэп"]),
-        ]
-        for label, keywords in keyword_map:
+        for label, keywords in KEYWORD_MAP:
             if any(token in corpus for token in keywords):
                 return label
         if emotion_profile:


### PR DESCRIPTION
## Summary
- move keyword and forced genre mappings from core_v6 into centralized config constants
- adjust core_v6 to import and use the new configuration constants without altering logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692207708554832788e67ad2e89e5f2b)