### PR TITLE
MAXI FIX v8 — Integrate DiagnosticsBuilderV8 into core_v6.py (structured diagnostics schema v8.0)

### DIFF
--- a/studiocore/core_v6.py
+++ b/studiocore/core_v6.py
@@ -69,6 +69,7 @@ from studiocore.emotion_map import EmotionMapEngine
 from studiocore.emotion_curve import build_global_emotion_curve
 from studiocore.frequency import RNSSafety, UniversalFrequencyEngine
 from studiocore.config import DEFAULT_CONFIG, FORCED_GENRES, KEYWORD_MAP
+from studiocore.diagnostics_v8 import DiagnosticsBuilderV8
 
 logger = logging.getLogger(__name__)
 
@@ -695,7 +696,12 @@ class StudioCoreV6:
         final_result = self._finalize_result(payload)
         final_result["engine"] = "StudioCoreV6"
         final_result.setdefault("ok", True)
-        final_result.setdefault("diagnostics", diagnostics)
+        structured_diagnostics = DiagnosticsBuilderV8(
+            base=diagnostics,
+            payload=final_result,
+        ).build()
+
+        final_result["diagnostics"] = structured_diagnostics
         final_result.setdefault("fanf", fanf)
         return final_result
 


### PR DESCRIPTION
## Summary
- import DiagnosticsBuilderV8 into core_v6 entry point
- normalize analyze() diagnostics output using DiagnosticsBuilderV8 while preserving legacy fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221160f3d483278c4e5aab973f6786)