### PR TITLE
Handle Gradio theme compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import traceback
 from typing import Any, Dict, List, Tuple
+import gradio
 import gradio as gr
 
 from studiocore.core_v6 import StudioCoreV6
@@ -230,7 +231,11 @@ def run_raw_diagnostics(text):
     except Exception as e:
         return {"error": str(e), "traceback": traceback.format_exc()}
 
-with gr.Blocks(theme=gr.themes.Soft(), title="StudioCore IMMORTAL v7 – Impulse Analysis") as demo:
+theme_kwargs = {}
+if gradio.__version__ >= "4.0.0":
+    theme_kwargs["theme"] = gr.themes.Soft()
+
+with gr.Blocks(title="StudioCore IMMORTAL v7 – Impulse Analysis", **theme_kwargs) as demo:
 
     gr.Markdown("# StudioCore IMMORTAL v7.0 — Impulse Analysis Engine")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 regex
 pydantic
-gradio
+gradio>=4.12.0
 python-dotenv
 PyYAML


### PR DESCRIPTION
## Summary
- require gradio>=4.12.0 to align with modern theme support
- apply theme parameter to Blocks only when running on Gradio 4+

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230c2fb5ec8332af39cd5a4f8d4691)