### PR TITLE
Add safe theme handling for older Gradio versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import traceback
 from typing import Any, Dict, List, Tuple
-import gradio
 import gradio as gr
 
 from studiocore.core_v6 import StudioCoreV6
@@ -231,9 +230,19 @@ def run_raw_diagnostics(text):
     except Exception as e:
         return {"error": str(e), "traceback": traceback.format_exc()}
 
-theme_kwargs = {}
-if gradio.__version__ >= "4.0.0":
-    theme_kwargs["theme"] = gr.themes.Soft()
+def _build_theme_kwargs():
+    try:
+        version = gr.__version__
+        major = int(version.split(".")[0])
+        # Gradio 4.x и выше — поддерживают theme=
+        if major >= 4:
+            return {"theme": gr.themes.Soft()}
+        else:
+            return {}
+    except Exception:
+        return {}
+
+theme_kwargs = _build_theme_kwargs()
 
 with gr.Blocks(title="StudioCore IMMORTAL v7 – Impulse Analysis", **theme_kwargs) as demo:
 


### PR DESCRIPTION
## Summary
- add a helper to build theme kwargs that only applies Gradio themes when supported
- remove the extra gradio import and reuse version info from the alias

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230d6b9f948332b5d27ff381308ef2)